### PR TITLE
Strategy should work with 1 replica

### DIFF
--- a/pkg/chart/cache/cache.go
+++ b/pkg/chart/cache/cache.go
@@ -27,6 +27,7 @@ func (f *fsCache) Fetch(repo, name, version string) (*bytes.Buffer, error) {
 
 	file := fmt.Sprintf("%s-%s.tgz", name, version)
 	path := filepath.Join(f.dir, repo, name, file)
+	path = strings.Replace(path, ":", "_", -1)
 	_, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -97,6 +98,7 @@ func (f *fsCache) Store(data []byte, repo, name, version string) error {
 	}
 
 	filename := fmt.Sprintf("%s-%s.tgz", name, version)
+	filename = strings.Replace(filename, ":", "_", -1)
 	chartPath := filepath.Join(familyPath, filename)
 
 	// Atomic rename swap to avoid cache hits against partially-written charts.
@@ -121,6 +123,7 @@ func clean(names ...string) (string, string, string) {
 		// names a nicer read (not http:__blorg.baz.com).
 		names[i] = strings.TrimPrefix(names[i], "https://")
 		names[i] = strings.TrimPrefix(names[i], "http://")
+		names[i] = strings.Replace(names[i], ":", "_", -1)
 		names[i] = strings.Replace(names[i], string(filepath.Separator), "_", -1)
 	}
 	return names[0], names[1], names[2]

--- a/pkg/chart/cache/cache_test.go
+++ b/pkg/chart/cache/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +69,7 @@ func TestCacheNameSanitization(t *testing.T) {
 			t.Fatalf("cleaned repoURL fetched chart different from stored data")
 		}
 
+		repoURL = strings.Replace(repoURL, ":", "_", -1)
 		unsanitizedPath := filepath.Join(testCacheDir, repoURL)
 		if _, err = os.Stat(unsanitizedPath); err == nil {
 			t.Fatalf("found a path at %q where there should be no path if santiziation is working", unsanitizedPath)

--- a/pkg/controller/capacity/capacity_controller.go
+++ b/pkg/controller/capacity/capacity_controller.go
@@ -2,7 +2,6 @@ package capacity
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/bookingcom/shipper/pkg/clusterclientstore"
 	"github.com/bookingcom/shipper/pkg/conditions"
 	shippercontroller "github.com/bookingcom/shipper/pkg/controller"
+	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
 const (
@@ -215,7 +215,7 @@ func (c *Controller) capacityTargetSyncHandler(key string) bool {
 
 		// Get the requested percentage of replicas from the capacity object. This is
 		// only set by the scheduler.
-		replicaCount := c.calculateReplicaCountFromPercentage(clusterSpec.TotalReplicaCount, clusterSpec.Percent)
+		replicaCount := int32(replicas.CalculateDesiredReplicaCount(uint(clusterSpec.TotalReplicaCount), float64(clusterSpec.Percent)))
 
 		// Patch the deployment if it doesn't match the cluster spec.
 		if targetDeployment.Spec.Replicas == nil || replicaCount != *targetDeployment.Spec.Replicas {
@@ -282,12 +282,6 @@ func (c *Controller) enqueueCapacityTarget(obj interface{}) {
 	}
 
 	c.capacityTargetWorkqueue.Add(key)
-}
-
-func (c Controller) calculateReplicaCountFromPercentage(total, percentage int32) int32 {
-	result := float64(percentage) / 100 * float64(total)
-
-	return int32(math.Ceil(result))
 }
 
 func (c *Controller) registerEventHandlers(informerFactory kubeinformers.SharedInformerFactory, clusterName string) {

--- a/pkg/controller/errors.go
+++ b/pkg/controller/errors.go
@@ -6,7 +6,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type MultipleOwnerReferencesError error
+type MultipleOwnerReferencesError string
+
+func (e MultipleOwnerReferencesError) Error() string {
+	return string(e)
+}
 
 func IsMultipleOwnerReferencesError(err error) bool {
 	_, ok := err.(MultipleOwnerReferencesError)
@@ -14,12 +18,16 @@ func IsMultipleOwnerReferencesError(err error) bool {
 }
 
 func NewMultipleOwnerReferencesError(name string, references int) MultipleOwnerReferencesError {
-	return MultipleOwnerReferencesError(fmt.Errorf(
+	return MultipleOwnerReferencesError(fmt.Sprintf(
 		"expected exactly one owner for object %q, got %d",
 		name, references))
 }
 
-type WrongOwnerReferenceError error
+type WrongOwnerReferenceError string
+
+func (e WrongOwnerReferenceError) Error() string {
+	return string(e)
+}
 
 func IsWrongOwnerReferenceError(err error) bool {
 	_, ok := err.(WrongOwnerReferenceError)
@@ -27,7 +35,7 @@ func IsWrongOwnerReferenceError(err error) bool {
 }
 
 func NewWrongOwnerReferenceError(name string, expectedUID, gotUID types.UID) WrongOwnerReferenceError {
-	return WrongOwnerReferenceError(fmt.Errorf(
+	return WrongOwnerReferenceError(fmt.Sprintf(
 		"the owner Release for InstallationTarget %q is gone; expected UID %s but got %s",
 		name,
 		expectedUID,

--- a/pkg/controller/strategy/checks.go
+++ b/pkg/controller/strategy/checks.go
@@ -58,7 +58,7 @@ type capacityState struct {
 func checkCapacity(
 	capacityTarget *shipperv1.CapacityTarget,
 	stepCapacity uint,
-	compFn func(achieved uint, desired uint) bool,
+	compFn func(achieved, desired, total uint) bool,
 ) (
 	bool,
 	*shipperv1.CapacityTargetSpec,
@@ -109,7 +109,7 @@ func checkCapacity(
 			newSpec.Clusters = append(newSpec.Clusters, r)
 			canProceed = false
 			clustersNotReady = append(clustersNotReady, clusterName)
-		} else if !compFn(v.achievedCapacity, v.desiredCapacity) {
+		} else if !compFn(v.achievedCapacity, v.desiredCapacity, uint(v.totalReplicaCount)) {
 			canProceed = false
 			clustersNotReady = append(clustersNotReady, clusterName)
 		}

--- a/pkg/controller/strategy/checks.go
+++ b/pkg/controller/strategy/checks.go
@@ -113,7 +113,7 @@ func checkCapacity(
 			newSpec.Clusters = append(newSpec.Clusters, r)
 			canProceed = false
 			clustersNotReady = append(clustersNotReady, clusterName)
-		} else if !replicasutil.AchievedDesiredReplicaPercentage(uint(v.totalReplicaCount), uint(v.currentReplicaCount), v.desiredCapacity) {
+		} else if !replicasutil.AchievedDesiredReplicaPercentage(uint(v.totalReplicaCount), uint(v.currentReplicaCount), float64(v.desiredCapacity)) {
 			canProceed = false
 			clustersNotReady = append(clustersNotReady, clusterName)
 		}

--- a/pkg/controller/strategy/comparisons.go
+++ b/pkg/controller/strategy/comparisons.go
@@ -1,11 +1,23 @@
 package strategy
 
-func contenderCapacityComparison(achieved uint, desired uint) bool {
-	return achieved >= desired
+func contenderCapacityComparison(achievedPercentage, desiredPercentage, totalNumberOfPods uint) bool {
+	// Consider that contender capacity has achieved its desired state if
+	// the end game is one pod and we already have it, as long as desired
+	// is greater than zero.
+	if totalNumberOfPods == 1 && achievedPercentage == 100 && desiredPercentage > 0 {
+		return true
+	}
+	return achievedPercentage >= desiredPercentage
 }
 
-func incumbentCapacityComparison(achieved uint, desired uint) bool {
-	return achieved <= desired
+func incumbentCapacityComparison(achievedPercentage, desiredPercentage, totalNumberOfPods uint) bool {
+	// Consider that the incumbent capacity has achieved its desired state if
+	// the end game is one pod and we already have it, as long as the desired
+	// is smaller than 100.
+	if totalNumberOfPods == 1 && achievedPercentage == 100 && desiredPercentage < 100 {
+		return true
+	}
+	return achievedPercentage <= desiredPercentage
 }
 
 func contenderTrafficComparison(achieved uint32, desired uint32) bool {

--- a/pkg/controller/strategy/comparisons.go
+++ b/pkg/controller/strategy/comparisons.go
@@ -1,25 +1,5 @@
 package strategy
 
-func contenderCapacityComparison(achievedPercentage, desiredPercentage, totalNumberOfPods uint) bool {
-	// Consider that contender capacity has achieved its desired state if
-	// the end game is one pod and we already have it, as long as desired
-	// is greater than zero.
-	if totalNumberOfPods == 1 && achievedPercentage == 100 && desiredPercentage > 0 {
-		return true
-	}
-	return achievedPercentage >= desiredPercentage
-}
-
-func incumbentCapacityComparison(achievedPercentage, desiredPercentage, totalNumberOfPods uint) bool {
-	// Consider that the incumbent capacity has achieved its desired state if
-	// the end game is one pod and we already have it, as long as the desired
-	// is smaller than 100.
-	if totalNumberOfPods == 1 && achievedPercentage == 100 && desiredPercentage < 100 {
-		return true
-	}
-	return achievedPercentage <= desiredPercentage
-}
-
 func contenderTrafficComparison(achieved uint32, desired uint32) bool {
 	return achieved >= desired
 }

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -30,130 +30,142 @@ func init() {
 }
 
 func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	// Strategy specifies that step 0 the contender has a minimum number of pods
-	// (1), no traffic yet.
-	contender.capacityTarget.Spec.Clusters[0].Percent = 1
+		// Strategy specifies that step 0 the contender has a minimum number of pods
+		// (1), no traffic yet.
+		contender.capacityTarget.Spec.Clusters[0].Percent = 1
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	rel := contender.release.DeepCopy()
-	f.expectReleaseWaitingForCommand(rel, 0)
-	f.run()
+		rel := contender.release.DeepCopy()
+		f.expectReleaseWaitingForCommand(rel, 0)
+		f.run()
+
+	}
 }
 
 func TestContenderDoNothingClusterInstallationNotReady(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	addCluster(contender, "broken-installation-cluster")
+		addCluster(contender, "broken-installation-cluster")
 
-	contender.release.Spec.TargetStep = 0
+		contender.release.Spec.TargetStep = 0
 
-	// the fixture creates installation targets in 'installation succeeded' status, so we'll break one
-	contender.installationTarget.Status.Clusters[1].Status = shipperv1.InstallationStatusFailed
+		// the fixture creates installation targets in 'installation succeeded' status,
+		// so we'll break one
+		contender.installationTarget.Status.Clusters[1].Status = shipperv1.InstallationStatusFailed
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	r := contender.release.DeepCopy()
-	f.expectInstallationNotReady(r, nil, 0, Contender)
-	f.run()
+		r := contender.release.DeepCopy()
+		f.expectInstallationNotReady(r, nil, 0, Contender)
+		f.run()
+	}
 }
 
 func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	brokenClusterName := "broken-capacity-cluster"
-	addCluster(contender, brokenClusterName)
+		brokenClusterName := "broken-capacity-cluster"
+		addCluster(contender, brokenClusterName)
 
-	// We'll set cluster 0 to be all set, but make cluster 1 broken.
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
-	contender.trafficTarget.Spec.Clusters[0].Weight = 50
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		// We'll set cluster 0 to be all set, but make cluster 1 broken.
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.trafficTarget.Spec.Clusters[0].Weight = 50
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
-	contender.capacityTarget.Spec.Clusters[1].Percent = 50
-	// No capacity yet.
-	contender.capacityTarget.Status.Clusters[1].AchievedPercent = 0
+		contender.capacityTarget.Spec.Clusters[1].Percent = 50
+		// No capacity yet.
+		contender.capacityTarget.Status.Clusters[1].AchievedPercent = 0
 
-	contender.trafficTarget.Spec.Clusters[1].Weight = 50
-	contender.trafficTarget.Status.Clusters[1].AchievedTraffic = 50
+		contender.trafficTarget.Spec.Clusters[1].Weight = 50
+		contender.trafficTarget.Status.Clusters[1].AchievedTraffic = 50
 
-	incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
-	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
-	incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
-	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
+		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	r := contender.release.DeepCopy()
-	f.expectCapacityNotReady(r, 1, 0, Contender, brokenClusterName)
-	f.run()
+		r := contender.release.DeepCopy()
+		f.expectCapacityNotReady(r, 1, 0, Contender, brokenClusterName)
+		f.run()
+	}
 }
 
 func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	brokenClusterName := "broken-traffic-cluster"
-	addCluster(contender, brokenClusterName)
-	// We'll set cluster 0 to be all set, but make cluster 1 broken.
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
-	contender.trafficTarget.Spec.Clusters[0].Weight = 50
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		brokenClusterName := "broken-traffic-cluster"
+		addCluster(contender, brokenClusterName)
+		// We'll set cluster 0 to be all set, but make cluster 1 broken.
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.trafficTarget.Spec.Clusters[0].Weight = 50
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
-	contender.capacityTarget.Spec.Clusters[1].Percent = 50
-	contender.capacityTarget.Status.Clusters[1].AchievedPercent = 50
+		contender.capacityTarget.Spec.Clusters[1].Percent = 50
+		contender.capacityTarget.Status.Clusters[1].AchievedPercent = 50
 
-	contender.trafficTarget.Spec.Clusters[1].Weight = 50
-	// No traffic yet.
-	contender.trafficTarget.Status.Clusters[1].AchievedTraffic = 0
+		contender.trafficTarget.Spec.Clusters[1].Weight = 50
+		// No traffic yet.
+		contender.trafficTarget.Status.Clusters[1].AchievedTraffic = 0
 
-	incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
-	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
-	incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
-	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
+		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	r := contender.release.DeepCopy()
-	f.expectTrafficNotReady(r, 1, 0, Contender, brokenClusterName)
-	f.run()
+		r := contender.release.DeepCopy()
+		f.expectTrafficNotReady(r, 1, 0, Contender, brokenClusterName)
+		f.run()
+	}
 }
 
 func TestContenderCapacityShouldIncrease(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 1
+		contender.release.Spec.TargetStep = 1
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	ct := contender.capacityTarget.DeepCopy()
-	r := contender.release.DeepCopy()
-	f.expectCapacityStatusPatch(ct, r, 50, totalReplicaCount, Contender)
-	f.run()
+		ct := contender.capacityTarget.DeepCopy()
+		r := contender.release.DeepCopy()
+		f.expectCapacityStatusPatch(ct, r, 50, totalReplicaCount, Contender)
+		f.run()
+	}
 }
 
 type role int
@@ -164,116 +176,126 @@ const (
 )
 
 func TestContenderTrafficShouldIncrease(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	tt := contender.trafficTarget.DeepCopy()
-	r := contender.release.DeepCopy()
-	f.expectTrafficStatusPatch(tt, r, 50, Contender)
-	f.run()
+		tt := contender.trafficTarget.DeepCopy()
+		r := contender.release.DeepCopy()
+		f.expectTrafficStatusPatch(tt, r, 50, Contender)
+		f.run()
+	}
 }
 
 func TestIncumbentTrafficShouldDecrease(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
-	contender.trafficTarget.Spec.Clusters[0].Weight = 50
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.trafficTarget.Spec.Clusters[0].Weight = 50
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	tt := incumbent.trafficTarget.DeepCopy()
-	r := contender.release.DeepCopy()
-	f.expectTrafficStatusPatch(tt, r, 50, Incumbent)
-	f.run()
+		tt := incumbent.trafficTarget.DeepCopy()
+		r := contender.release.DeepCopy()
+		f.expectTrafficStatusPatch(tt, r, 50, Incumbent)
+		f.run()
+	}
 }
 
 func TestIncumbentCapacityShouldDecrease(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
-	contender.trafficTarget.Spec.Clusters[0].Weight = 50
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
-	incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
-	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.trafficTarget.Spec.Clusters[0].Weight = 50
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
+		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	tt := incumbent.capacityTarget.DeepCopy()
-	r := contender.release.DeepCopy()
-	f.expectCapacityStatusPatch(tt, r, 50, totalReplicaCount, Incumbent)
-	f.run()
+		tt := incumbent.capacityTarget.DeepCopy()
+		r := contender.release.DeepCopy()
+		f.expectCapacityStatusPatch(tt, r, 50, totalReplicaCount, Incumbent)
+		f.run()
+	}
 }
 
 func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 1
-	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
-	contender.trafficTarget.Spec.Clusters[0].Weight = 50
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
-	incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
-	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
-	incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
-	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.release.Spec.TargetStep = 1
+		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.trafficTarget.Spec.Clusters[0].Weight = 50
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
+		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	rel := contender.release.DeepCopy()
-	f.expectReleaseWaitingForCommand(rel, 1)
-	f.run()
+		rel := contender.release.DeepCopy()
+		f.expectReleaseWaitingForCommand(rel, 1)
+		f.run()
+	}
 }
 
 func TestContenderReleaseIsInstalled(t *testing.T) {
-	f := newFixture(t)
+	for _, i := range []uint{1, 10} {
+		f := newFixture(t)
 
-	totalReplicaCount := uint(10)
-	contender := buildContender(totalReplicaCount)
-	incumbent := buildIncumbent(totalReplicaCount)
+		totalReplicaCount := i
+		contender := buildContender(totalReplicaCount)
+		incumbent := buildIncumbent(totalReplicaCount)
 
-	contender.release.Spec.TargetStep = 2
-	contender.capacityTarget.Spec.Clusters[0].Percent = 100
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 100
-	contender.trafficTarget.Spec.Clusters[0].Weight = 100
-	contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 100
-	releaseutil.SetReleaseCondition(&contender.release.Status, shipperv1.ReleaseCondition{Type: shipperv1.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue, Reason: "", Message: ""})
+		contender.release.Spec.TargetStep = 2
+		contender.capacityTarget.Spec.Clusters[0].Percent = 100
+		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 100
+		contender.trafficTarget.Spec.Clusters[0].Weight = 100
+		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 100
+		releaseutil.SetReleaseCondition(&contender.release.Status, shipperv1.ReleaseCondition{Type: shipperv1.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue, Reason: "", Message: ""})
 
-	incumbent.trafficTarget.Spec.Clusters[0].Weight = 0
-	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 0
-	incumbent.capacityTarget.Spec.Clusters[0].Percent = 0
-	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 0
+		incumbent.trafficTarget.Spec.Clusters[0].Weight = 0
+		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 0
+		incumbent.capacityTarget.Spec.Clusters[0].Percent = 0
+		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 0
 
-	f.addObjects(contender, incumbent)
+		f.addObjects(contender, incumbent)
 
-	f.expectReleaseReleased(contender.release.DeepCopy(), 2)
+		f.expectReleaseReleased(contender.release.DeepCopy(), 2)
 
-	f.run()
+		f.run()
+	}
 }
 
 func workingOnContenderCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -350,7 +350,7 @@ func workingOnContenderCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
 	contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 	contender.capacityTarget.Status.Clusters[0].AchievedPercent = achievedCapacityPercentage
-	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, uint(achievedCapacityPercentage)))
+	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, float64(achievedCapacityPercentage)))
 
 	f.addObjects(contender, incumbent)
 
@@ -450,7 +450,7 @@ func workingOnIncumbentCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 	incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
 	incumbent.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = incumbentAchievedCapacityPercentage
-	incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, uint(incumbentAchievedCapacityPercentage)))
+	incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, float64(incumbentAchievedCapacityPercentage)))
 
 	f.addObjects(contender, incumbent)
 

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bookingcom/shipper/pkg/conditions"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
+	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
 func init() {
@@ -40,6 +41,9 @@ func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.
 		// Strategy specifies that step 0 the contender has a minimum number of pods
 		// (1), no traffic yet.
 		contender.capacityTarget.Spec.Clusters[0].Percent = 1
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = 1
+		incumbent.capacityTarget.Spec.Clusters[0].Percent = 100
+		incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(totalReplicaCount)
 
 		f.addObjects(contender, incumbent)
 
@@ -88,21 +92,26 @@ func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
 		// We'll set cluster 0 to be all set, but make cluster 1 broken.
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 		contender.trafficTarget.Spec.Clusters[0].Weight = 50
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
-		contender.capacityTarget.Spec.Clusters[1].Percent = 50
 		// No capacity yet.
+		contender.capacityTarget.Spec.Clusters[1].Percent = 50
+		contender.capacityTarget.Spec.Clusters[1].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[1].AchievedPercent = 0
-
+		contender.capacityTarget.Status.Clusters[1].AvailableReplicas = 0
 		contender.trafficTarget.Spec.Clusters[1].Weight = 50
 		contender.trafficTarget.Status.Clusters[1].AchievedTraffic = 50
 
 		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 		f.addObjects(contender, incumbent)
 
@@ -122,15 +131,20 @@ func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
 
 		brokenClusterName := "broken-traffic-cluster"
 		addCluster(contender, brokenClusterName)
+
 		// We'll set cluster 0 to be all set, but make cluster 1 broken.
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 		contender.trafficTarget.Spec.Clusters[0].Weight = 50
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
 		contender.capacityTarget.Spec.Clusters[1].Percent = 50
+		contender.capacityTarget.Spec.Clusters[1].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[1].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[1].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 		contender.trafficTarget.Spec.Clusters[1].Weight = 50
 		// No traffic yet.
@@ -139,7 +153,9 @@ func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
 		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 		f.addObjects(contender, incumbent)
 
@@ -185,7 +201,9 @@ func TestContenderTrafficShouldIncrease(t *testing.T) {
 
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 		f.addObjects(contender, incumbent)
 
@@ -206,7 +224,9 @@ func TestIncumbentTrafficShouldDecrease(t *testing.T) {
 
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 		contender.trafficTarget.Spec.Clusters[0].Weight = 50
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
@@ -229,9 +249,12 @@ func TestIncumbentCapacityShouldDecrease(t *testing.T) {
 
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 		contender.trafficTarget.Spec.Clusters[0].Weight = 50
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
+
 		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
@@ -254,13 +277,17 @@ func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T)
 
 		contender.release.Spec.TargetStep = 1
 		contender.capacityTarget.Spec.Clusters[0].Percent = 50
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 		contender.trafficTarget.Spec.Clusters[0].Weight = 50
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 		incumbent.trafficTarget.Spec.Clusters[0].Weight = 50
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 		incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
+		incumbent.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+		incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 		f.addObjects(contender, incumbent)
 
@@ -280,7 +307,9 @@ func TestContenderReleaseIsInstalled(t *testing.T) {
 
 		contender.release.Spec.TargetStep = 2
 		contender.capacityTarget.Spec.Clusters[0].Percent = 100
+		contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 		contender.capacityTarget.Status.Clusters[0].AchievedPercent = 100
+		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(totalReplicaCount)
 		contender.trafficTarget.Spec.Clusters[0].Weight = 100
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 100
 		releaseutil.SetReleaseCondition(&contender.release.Status, shipperv1.ReleaseCondition{Type: shipperv1.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue, Reason: "", Message: ""})
@@ -289,6 +318,7 @@ func TestContenderReleaseIsInstalled(t *testing.T) {
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 0
 		incumbent.capacityTarget.Spec.Clusters[0].Percent = 0
 		incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 0
+		incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = 0
 
 		f.addObjects(contender, incumbent)
 
@@ -309,9 +339,13 @@ func workingOnContenderCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	contender.release.Spec.TargetStep = 1
 
+	achievedCapacityPercentage := 100 - int32(percent)
+
 	// Working on contender capacity.
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
-	contender.capacityTarget.Status.Clusters[0].AchievedPercent = int32(percent)
+	contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
+	contender.capacityTarget.Status.Clusters[0].AchievedPercent = achievedCapacityPercentage
+	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, uint(achievedCapacityPercentage)))
 
 	f.addObjects(contender, incumbent)
 
@@ -333,7 +367,9 @@ func workingOnContenderTraffic(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	// Desired contender capacity achieved.
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
+	contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 	// Working on contender traffic.
 	contender.trafficTarget.Spec.Clusters[0].Weight = 50
@@ -360,7 +396,9 @@ func workingOnIncumbentTraffic(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	// Desired contender capacity achieved.
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
+	contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 	// Desired contender traffic achieved.
 	contender.trafficTarget.Spec.Clusters[0].Weight = 50
@@ -390,7 +428,9 @@ func workingOnIncumbentCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	// Desired contender capacity achieved.
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
+	contender.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
 	contender.capacityTarget.Status.Clusters[0].AchievedPercent = 50
+	contender.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, 50))
 
 	// Desired contender traffic achieved.
 	contender.trafficTarget.Spec.Clusters[0].Weight = 50
@@ -401,8 +441,11 @@ func workingOnIncumbentCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 	incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 50
 
 	// Working on incumbent capacity.
+	incumbentAchievedCapacityPercentage := 100 - int32(percent)
 	incumbent.capacityTarget.Spec.Clusters[0].Percent = 50
-	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = 100 - int32(percent)
+	incumbent.capacityTarget.Spec.Clusters[0].TotalReplicaCount = int32(totalReplicaCount)
+	incumbent.capacityTarget.Status.Clusters[0].AchievedPercent = incumbentAchievedCapacityPercentage
+	incumbent.capacityTarget.Status.Clusters[0].AvailableReplicas = int32(replicas.CalculateDesiredReplicaCount(totalReplicaCount, uint(incumbentAchievedCapacityPercentage)))
 
 	f.addObjects(contender, incumbent)
 

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -32,8 +32,9 @@ func init() {
 func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	// Strategy specifies that step 0 the contender has a minimum number of pods
 	// (1), no traffic yet.
@@ -49,8 +50,9 @@ func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.
 func TestContenderDoNothingClusterInstallationNotReady(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	addCluster(contender, "broken-installation-cluster")
 
@@ -69,8 +71,9 @@ func TestContenderDoNothingClusterInstallationNotReady(t *testing.T) {
 func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	brokenClusterName := "broken-capacity-cluster"
 	addCluster(contender, brokenClusterName)
@@ -104,8 +107,9 @@ func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
 func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	brokenClusterName := "broken-traffic-cluster"
 	addCluster(contender, brokenClusterName)
@@ -138,8 +142,9 @@ func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
 func TestContenderCapacityShouldIncrease(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 
@@ -147,7 +152,7 @@ func TestContenderCapacityShouldIncrease(t *testing.T) {
 
 	ct := contender.capacityTarget.DeepCopy()
 	r := contender.release.DeepCopy()
-	f.expectCapacityStatusPatch(ct, r, 50, Contender)
+	f.expectCapacityStatusPatch(ct, r, 50, totalReplicaCount, Contender)
 	f.run()
 }
 
@@ -161,8 +166,9 @@ const (
 func TestContenderTrafficShouldIncrease(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
@@ -179,8 +185,9 @@ func TestContenderTrafficShouldIncrease(t *testing.T) {
 func TestIncumbentTrafficShouldDecrease(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
@@ -199,8 +206,9 @@ func TestIncumbentTrafficShouldDecrease(t *testing.T) {
 func TestIncumbentCapacityShouldDecrease(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
@@ -214,15 +222,16 @@ func TestIncumbentCapacityShouldDecrease(t *testing.T) {
 
 	tt := incumbent.capacityTarget.DeepCopy()
 	r := contender.release.DeepCopy()
-	f.expectCapacityStatusPatch(tt, r, 50, Incumbent)
+	f.expectCapacityStatusPatch(tt, r, 50, totalReplicaCount, Incumbent)
 	f.run()
 }
 
 func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 	contender.capacityTarget.Spec.Clusters[0].Percent = 50
@@ -244,8 +253,9 @@ func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T)
 func TestContenderReleaseIsInstalled(t *testing.T) {
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 2
 	contender.capacityTarget.Spec.Clusters[0].Percent = 100
@@ -271,8 +281,9 @@ func workingOnContenderCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 
@@ -292,8 +303,9 @@ func workingOnContenderTraffic(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 
@@ -318,8 +330,9 @@ func workingOnIncumbentTraffic(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 
@@ -347,8 +360,9 @@ func workingOnIncumbentCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 
 	f := newFixture(t)
 
-	contender := buildContender()
-	incumbent := buildIncumbent()
+	totalReplicaCount := uint(10)
+	contender := buildContender(totalReplicaCount)
+	incumbent := buildIncumbent(totalReplicaCount)
 
 	contender.release.Spec.TargetStep = 1
 
@@ -505,12 +519,12 @@ func (f *fixture) run() {
 	shippertesting.CheckEvents(f.expectedOrderedEvents, f.receivedEvents, f.t)
 }
 
-func (f *fixture) expectCapacityStatusPatch(ct *shipperv1.CapacityTarget, r *shipperv1.Release, value uint, role role) {
+func (f *fixture) expectCapacityStatusPatch(ct *shipperv1.CapacityTarget, r *shipperv1.Release, value uint, totalReplicaCount uint, role role) {
 	gvr := shipperv1.SchemeGroupVersion.WithResource("capacitytargets")
 	newSpec := map[string]interface{}{
 		"spec": shipperv1.CapacityTargetSpec{
 			Clusters: []shipperv1.ClusterCapacityTarget{
-				{Name: "minikube", Percent: int32(value)},
+				{Name: "minikube", Percent: int32(value), TotalReplicaCount: int32(totalReplicaCount)},
 			},
 		},
 	}

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -30,8 +30,13 @@ func init() {
 	conditions.StrategyConditionsShouldDiscardTimestamps = true
 }
 
+// interestingReplicaCounts represents number of replicas that we've seen
+// Shipper misbehave because of wrong replica counts based on the percentages
+// the strategy specifies.
+var interestingReplicaCounts = []uint{1, 3, 10}
+
 func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -55,7 +60,7 @@ func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.
 }
 
 func TestContenderDoNothingClusterInstallationNotReady(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -79,7 +84,7 @@ func TestContenderDoNothingClusterInstallationNotReady(t *testing.T) {
 }
 
 func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -122,7 +127,7 @@ func TestContenderDoNothingClusterCapacityNotReady(t *testing.T) {
 }
 
 func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -166,7 +171,7 @@ func TestContenderDoNothingClusterTrafficNotReady(t *testing.T) {
 }
 
 func TestContenderCapacityShouldIncrease(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -192,7 +197,7 @@ const (
 )
 
 func TestContenderTrafficShouldIncrease(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -215,7 +220,7 @@ func TestContenderTrafficShouldIncrease(t *testing.T) {
 }
 
 func TestIncumbentTrafficShouldDecrease(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -240,7 +245,7 @@ func TestIncumbentTrafficShouldDecrease(t *testing.T) {
 }
 
 func TestIncumbentCapacityShouldDecrease(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -268,7 +273,7 @@ func TestIncumbentCapacityShouldDecrease(t *testing.T) {
 }
 
 func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i
@@ -298,7 +303,7 @@ func TestContenderReleasePhaseIsWaitingForCommandForFinalStepState(t *testing.T)
 }
 
 func TestContenderReleaseIsInstalled(t *testing.T) {
-	for _, i := range []uint{1, 10} {
+	for _, i := range interestingReplicaCounts {
 		f := newFixture(t)
 
 		totalReplicaCount := i

--- a/pkg/controller/strategy/executor.go
+++ b/pkg/controller/strategy/executor.go
@@ -131,7 +131,7 @@ func (s *Executor) execute() ([]ExecutorResult, []ReleaseStrategyStateTransition
 		//
 		capacityWeight := strategyStep.Capacity.Contender
 
-		if achieved, newSpec, clustersNotReady := checkCapacity(s.contender.capacityTarget, uint(capacityWeight), contenderCapacityComparison); !achieved {
+		if achieved, newSpec, clustersNotReady := checkCapacity(s.contender.capacityTarget, uint(capacityWeight)); !achieved {
 			s.info("contender %q hasn't achieved capacity yet", s.contender.release.Name)
 
 			var patches []ExecutorResult
@@ -257,7 +257,7 @@ func (s *Executor) execute() ([]ExecutorResult, []ReleaseStrategyStateTransition
 		//
 		capacityWeight := strategyStep.Capacity.Incumbent
 
-		if achieved, newSpec, clustersNotReady := checkCapacity(s.incumbent.capacityTarget, uint(capacityWeight), incumbentCapacityComparison); !achieved {
+		if achieved, newSpec, clustersNotReady := checkCapacity(s.incumbent.capacityTarget, uint(capacityWeight)); !achieved {
 			s.info("incumbent %q hasn't achieved capacity yet", s.incumbent.release.Name)
 
 			var patches []ExecutorResult

--- a/pkg/controller/strategy/executor_test.go
+++ b/pkg/controller/strategy/executor_test.go
@@ -61,8 +61,8 @@ var vanguard = shipperv1.RolloutStrategy{
 // the expected for the strategy at a given moment.
 func TestCompleteStrategyNoController(t *testing.T) {
 	executor := &Executor{
-		contender: buildContender(),
-		incumbent: buildIncumbent(),
+		contender: buildContender(10),
+		incumbent: buildIncumbent(10),
 		recorder:  record.NewFakeRecorder(42),
 		strategy:  vanguard,
 	}
@@ -192,7 +192,7 @@ func TestCompleteStrategyNoController(t *testing.T) {
 
 // buildIncumbent returns a releaseInfo with an incumbent release and
 // associated objects.
-func buildIncumbent() *releaseInfo {
+func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 
 	rel := &shipperv1.Release{
 		TypeMeta: metav1.TypeMeta{
@@ -292,8 +292,9 @@ func buildIncumbent() *releaseInfo {
 		Spec: shipperv1.CapacityTargetSpec{
 			Clusters: []shipperv1.ClusterCapacityTarget{
 				{
-					Name:    clusterName,
-					Percent: 100,
+					Name:              clusterName,
+					Percent:           100,
+					TotalReplicaCount: int32(totalReplicaCount),
 				},
 			},
 		},
@@ -342,7 +343,7 @@ func buildIncumbent() *releaseInfo {
 
 // buildContender returns a releaseInfo with a contender release and
 // associated objects.
-func buildContender() *releaseInfo {
+func buildContender(totalReplicaCount uint) *releaseInfo {
 	rel := &shipperv1.Release{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "shipper.booking.com/v1",
@@ -437,8 +438,9 @@ func buildContender() *releaseInfo {
 		Spec: shipperv1.CapacityTargetSpec{
 			Clusters: []shipperv1.ClusterCapacityTarget{
 				{
-					Name:    clusterName,
-					Percent: 0,
+					Name:              clusterName,
+					Percent:           0,
+					TotalReplicaCount: int32(totalReplicaCount),
 				},
 			},
 		},

--- a/pkg/controller/traffic/pod_label_shifter.go
+++ b/pkg/controller/traffic/pod_label_shifter.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	shipperv1 "github.com/bookingcom/shipper/pkg/apis/shipper/v1"
+	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
 type podLabelShifter struct {
@@ -217,13 +218,15 @@ func calculateReleasePodTarget(releasePods int, releaseWeight uint32, totalPods 
 	if totalWeight == 0 {
 		targetPercent = 0
 	} else {
-		targetPercent = float64(releaseWeight) / float64(totalWeight)
+		targetPercent = float64(releaseWeight) / float64(totalWeight) * 100
 	}
 	// Round up to the nearest pod, clamped to the number of pods this release has.
-	targetPods := int(
+	targetPods := int(replicas.CalculateDesiredReplicaCount(uint(totalPods), float64(targetPercent)))
+
+	targetPods = int(
 		math.Min(
 			float64(releasePods),
-			math.Ceil(targetPercent*float64(totalPods)),
+			float64(targetPods),
 		),
 	)
 	return targetPods

--- a/pkg/util/replicas/replicas.go
+++ b/pkg/util/replicas/replicas.go
@@ -18,7 +18,7 @@ import (
 // 0, 1, 2, 3 and 3. Those values are based on where the desired percentage
 // falls on the divisible slices of 3 replicas: 0%, 1%-33%, 34%-66% and
 // 67%-100%.
-func CalculateDesiredReplicaCount(totalReplicaCount, desiredCapacityPercentage uint) uint {
+func CalculateDesiredReplicaCount(totalReplicaCount uint, desiredCapacityPercentage float64) uint {
 	desiredReplicaCount := math.Ceil(float64(totalReplicaCount) * float64(desiredCapacityPercentage) / 100)
 	return uint(desiredReplicaCount)
 }
@@ -30,7 +30,7 @@ func CalculateDesiredReplicaCount(totalReplicaCount, desiredCapacityPercentage u
 // case the informed desiredPercentage value is greater than 100, this
 // function will panic; it is the caller's responsibility to check if the
 // value falls in the 0-100 range.
-func AchievedDesiredReplicaPercentage(totalReplicaCount, currentReplicaCount, desiredPercentage uint) bool {
+func AchievedDesiredReplicaPercentage(totalReplicaCount, currentReplicaCount uint, desiredPercentage float64) bool {
 	if desiredPercentage > 100 {
 		panic("Programmer error: desiredPercentage should be a value between 0 and 100 inclusive")
 	}

--- a/pkg/util/replicas/replicas.go
+++ b/pkg/util/replicas/replicas.go
@@ -1,0 +1,39 @@
+package replicas
+
+import (
+	"math"
+)
+
+// CalculateDesiredNumberOfReplicas extracts the optimal replica count for
+// the given totalReplicaCount and desiredCapacityPercentage values.
+//
+// The returned value is a ceil'ed replica count calculated as a percentage
+// of the given totalReplicaCount value. One of the considerations here is
+// that the returned value will always return a replica count that is greater
+// than the actual desired, and that is by design: we rather over than under
+// capacity a deployment during a release process.
+//
+// Considering the following strategy: 0%, 25%, 50%, 75% and 100% of 3 total
+// replicas; this method will yield, the respective number of desired replicas:
+// 0, 1, 2, 3 and 3. Those values are based on where the desired percentage
+// falls on the divisible slices of 3 replicas: 0%, 1%-33%, 34%-66% and
+// 67%-100%.
+func CalculateDesiredReplicaCount(totalReplicaCount, desiredCapacityPercentage uint) uint {
+	desiredReplicaCount := math.Ceil(float64(totalReplicaCount) * float64(desiredCapacityPercentage) / 100)
+	return uint(desiredReplicaCount)
+}
+
+// AchievedDesiredCapacity verifies whether the given currentReplicaCount
+// and totalReplicaCount match the given desiredCapacityPercentage.
+//
+// Please note desiredPercentage might be a value between 0 and 100. In the
+// case the informed desiredPercentage value is greater than 100, this
+// function will panic; it is the caller's responsibility to check if the
+// value falls in the 0-100 range.
+func AchievedDesiredReplicaPercentage(totalReplicaCount, currentReplicaCount, desiredPercentage uint) bool {
+	if desiredPercentage > 100 {
+		panic("Programmer error: desiredPercentage should be a value between 0 and 100 inclusive")
+	}
+
+	return currentReplicaCount == CalculateDesiredReplicaCount(totalReplicaCount, desiredPercentage)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -267,14 +267,23 @@ func testNewApplicationVanguard(targetReplicas int, t *testing.T) {
 	}
 }
 
+// TestNewApplicationVanguardMultipleReplicas tests the creation of a new
+// application with multiple replicas, marching through the specified vanguard
+// strategy until it hopefully converges on the final desired state.
 func TestNewApplicationVanguardMultipleReplicas(t *testing.T) {
-	testNewApplicationVanguard(4, t)
+	testNewApplicationVanguard(3, t)
 }
 
+// TestNewApplicationVanguardOneReplica tests the creation of a new
+// application with one replica, marching through the specified vanguard
+// strategy until it hopefully converges on the final desired state.
 func TestNewApplicationVanguardOneReplica(t *testing.T) {
 	testNewApplicationVanguard(1, t)
 }
 
+// testRolloutVanguard tests the creation of a new application with the
+// specified number of replicas, marching through the specified vanguard
+// strategy until it hopefully converges on the final desired state.
 func testRolloutVanguard(targetReplicas int, t *testing.T) {
 	if !*runEndToEnd {
 		t.Skip("skipping end-to-end tests: --e2e is false")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -217,13 +217,12 @@ func TestRolloutAllIn(t *testing.T) {
 	f.checkPods(contender.GetName(), targetReplicas)
 }
 
-func TestNewApplicationVanguard(t *testing.T) {
+func testNewApplicationVanguard(targetReplicas int, t *testing.T) {
 	if !*runEndToEnd {
 		t.Skip("skipping end-to-end tests: --e2e is false")
 	}
 
 	t.Parallel()
-	targetReplicas := 4
 	ns, err := setupNamespace(t.Name())
 	f := newFixture(ns.GetName(), t)
 	if err != nil {
@@ -268,13 +267,20 @@ func TestNewApplicationVanguard(t *testing.T) {
 	}
 }
 
-func TestRolloutVanguard(t *testing.T) {
+func TestNewApplicationVanguardMultipleReplicas(t *testing.T) {
+	testNewApplicationVanguard(4, t)
+}
+
+func TestNewApplicationVanguardOneReplica(t *testing.T) {
+	testNewApplicationVanguard(1, t)
+}
+
+func testRolloutVanguard(targetReplicas int, t *testing.T) {
 	if !*runEndToEnd {
 		t.Skip("skipping end-to-end tests: --e2e is false")
 	}
 
 	t.Parallel()
-	targetReplicas := 4
 	ns, err := setupNamespace(t.Name())
 	f := newFixture(ns.GetName(), t)
 	if err != nil {
@@ -343,6 +349,14 @@ func TestRolloutVanguard(t *testing.T) {
 		f.checkPods(contenderName, expectedContenderCapacity)
 		f.checkPods(incumbentName, expectedIncumbentCapacity)
 	}
+}
+
+func TestRolloutVanguardMultipleReplicas(t *testing.T) {
+	testRolloutVanguard(4, t)
+}
+
+func TestRolloutVanguardOneReplica(t *testing.T) {
+	testRolloutVanguard(1, t)
 }
 
 // TODO(btyler): cover a variety of broken chart cases as soon as we report


### PR DESCRIPTION
This patch makes sure that the strategy works with one replica as well as many.

The intended behavior was to not complete the strategy right away but march through the strategy specification even if the whole transition capacity has been fulfilled.

Closes #7.