### PR TITLE
metrics: capture discovery requests in the REST client

### DIFF
--- a/pkg/metrics/prometheus/restclient.go
+++ b/pkg/metrics/prometheus/restclient.go
@@ -82,6 +82,9 @@ func extractGVR(path string) string {
 
 	if prefix == "apis" {
 		switch len(pieces) {
+		case 2:
+			// shipper.booking.com/v1
+			gvr = pieces[0] + "/" + pieces[1] // not a GVR but still useful to see
 		case 3:
 			// shipper.booking.com/v1/traffictargets
 			gvr = pieces[0] + "/" + pieces[1] + "/" + pieces[2]


### PR DESCRIPTION
It can be useful to see resource discovery requests on the graphs, especially considering that we're not super efficient in how we manage resource clients in the installation controller.