### PR TITLE
E2E test when a strategy is moving backwards refs #13

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -409,9 +409,7 @@ func TestNewApplicationMovingStrategyBackwards(t *testing.T) {
 		t.Logf("waiting for release %q to achieve waitingForCommand for targetStep %d", relName, i)
 		f.waitForCommand(relName, i)
 
-		expectedCapacity := replicas.CalculateDesiredReplicaCount(uint(step.Capacity.Contender), float64(targetReplicas)) //capacityInPods(step.Capacity.Contender, targetReplicas)
-		// expectedContenderCapacity := replicas.CalculateDesiredReplicaCount(uint(step.Capacity.Contender), float64(targetReplicas))
-		// expectedIncumbentCapacity := replicas.CalculateDesiredReplicaCount(uint(step.Capacity.Incumbent), float64(targetReplicas))
+		expectedCapacity := replicas.CalculateDesiredReplicaCount(uint(step.Capacity.Contender), float64(targetReplicas))
 		t.Logf("checking that release %q has %d pods (strategy step %d aka %q)", relName, expectedCapacity, i, step.Name)
 		f.checkPods(relName, int(expectedCapacity))
 	}


### PR DESCRIPTION
This commit adds 2 new e2e test cases where a rollout strategy is
being tested against a revert scenario. We are testing 2 distinct
scenarios: a brand new application and an existing one rolling
forward. In both cases we are using the existing vanguard strategy:
0 | 50/50 | full-on. New tests are moving the release from step 0
towards 50/50 and revert immediately.