### PR TITLE
ci: add -e to test.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 CGO_ENABLED=0 GOOS=linux go build -v -o shipper cmd/shipper/*.go
 CGO_ENABLED=0 GOOS=linux go build -v -o shipper-state-metrics cmd/shipper-state-metrics/*.go

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 dep status -v
 


### PR DESCRIPTION
'go test' exiting non-zero was not causing the build to fail