### PR TITLE
controllers: replace 'shipper.booking.com/v1alpha1' with constant

### DIFF
--- a/pkg/controller/application/application_controller_test.go
+++ b/pkg/controller/application/application_controller_test.go
@@ -604,7 +604,7 @@ func newRelease(releaseName string, app *shipper.Application) *shipper.Release {
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Application",
 					Name:       app.GetName(),
 				},

--- a/pkg/controller/application/application_controller_utils.go
+++ b/pkg/controller/application/application_controller_utils.go
@@ -135,7 +135,7 @@ func createOwnerRefFromApplication(app *shipper.Application) metav1.OwnerReferen
 	// https://github.com/kubernetes/client-go/issues/60#issuecomment-281747911 for
 	// context.
 	return metav1.OwnerReference{
-		APIVersion: "shipper.booking.com/v1alpha1",
+		APIVersion: shipper.SchemeGroupVersion.String(),
 		Kind:       "Application",
 		Name:       app.GetName(),
 		UID:        app.GetUID(),

--- a/pkg/controller/capacity/capacity_controller_test.go
+++ b/pkg/controller/capacity/capacity_controller_test.go
@@ -201,7 +201,11 @@ func (f *fixture) expectCapacityTargetStatusUpdate(capacityTarget *shipper.Capac
 	capacityTarget.Status.Clusters = append(capacityTarget.Status.Clusters, clusterStatus)
 
 	updateAction := kubetesting.NewUpdateAction(
-		schema.GroupVersionResource{Group: "shipper.booking.com", Version: "v1alpha1", Resource: "capacitytargets"},
+		schema.GroupVersionResource{
+			Group:    shipper.SchemeGroupVersion.Group,
+			Version:  shipper.SchemeGroupVersion.Version,
+			Resource: "capacitytargets",
+		},
 		capacityTarget.GetNamespace(),
 		capacityTarget,
 	)
@@ -231,7 +235,7 @@ func newCapacityTarget(totalReplicaCount, percent int32) *shipper.CapacityTarget
 			Labels:    metaLabels,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Release",
 					Name:       "0.0.1",
 				},

--- a/pkg/controller/clustersecret/clustersecret_controller_test.go
+++ b/pkg/controller/clustersecret/clustersecret_controller_test.go
@@ -161,7 +161,7 @@ func newClusterSecret(cluster *shipper.Cluster, p tls.Pair) *corev1.Secret {
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Cluster",
 					Name:       name,
 					UID:        cluster.GetUID(),

--- a/pkg/controller/clustersecret/clustersecret_controller_utils.go
+++ b/pkg/controller/clustersecret/clustersecret_controller_utils.go
@@ -80,7 +80,7 @@ func (c *Controller) createSecretForCluster(cluster *shipper.Cluster, crt, key, 
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Cluster",
 					Name:       cluster.GetName(),
 					UID:        cluster.GetUID(),

--- a/pkg/controller/installation/controller_test.go
+++ b/pkg/controller/installation/controller_test.go
@@ -123,7 +123,11 @@ func TestInstallOneCluster(t *testing.T) {
 		},
 	}
 	expectedActions = []kubetesting.Action{
-		kubetesting.NewUpdateAction(schema.GroupVersionResource{Resource: "installationtargets", Version: "v1alpha1", Group: "shipper.booking.com"}, release.GetNamespace(), it),
+		kubetesting.NewUpdateAction(schema.GroupVersionResource{
+			Resource: "installationtargets",
+			Version:  shipper.SchemeGroupVersion.Version,
+			Group:    shipper.SchemeGroupVersion.Group,
+		}, release.GetNamespace(), it),
 	}
 	shippertesting.CheckActions(expectedActions, filteredActions, t)
 }
@@ -219,7 +223,11 @@ func TestInstallMultipleClusters(t *testing.T) {
 		},
 	}
 	expectedActions = []kubetesting.Action{
-		kubetesting.NewUpdateAction(schema.GroupVersionResource{Resource: "installationtargets", Version: "v1alpha1", Group: "shipper.booking.com"}, release.GetNamespace(), it),
+		kubetesting.NewUpdateAction(schema.GroupVersionResource{
+			Resource: "installationtargets",
+			Version:  shipper.SchemeGroupVersion.Version,
+			Group:    shipper.SchemeGroupVersion.Group,
+		}, release.GetNamespace(), it),
 	}
 	shippertesting.CheckActions(expectedActions, filteredActions, t)
 }
@@ -336,7 +344,11 @@ func TestClientError(t *testing.T) {
 		},
 	}
 	expectedActions := []kubetesting.Action{
-		kubetesting.NewUpdateAction(schema.GroupVersionResource{Resource: "installationtargets", Version: "v1alpha1", Group: "shipper.booking.com"}, release.GetNamespace(), it),
+		kubetesting.NewUpdateAction(schema.GroupVersionResource{
+			Resource: "installationtargets",
+			Version:  shipper.SchemeGroupVersion.Version,
+			Group:    shipper.SchemeGroupVersion.Group,
+		}, release.GetNamespace(), it),
 	}
 	var filteredActions []kubetesting.Action
 	for _, a := range shipperclientset.Actions() {
@@ -413,7 +425,11 @@ func TestTargetClusterMissesGVK(t *testing.T) {
 		},
 	}
 	expectedActions := []kubetesting.Action{
-		kubetesting.NewUpdateAction(schema.GroupVersionResource{Resource: "installationtargets", Version: "v1alpha1", Group: "shipper.booking.com"}, release.GetNamespace(), it),
+		kubetesting.NewUpdateAction(schema.GroupVersionResource{
+			Resource: "installationtargets",
+			Version:  shipper.SchemeGroupVersion.Version,
+			Group:    shipper.SchemeGroupVersion.Group,
+		}, release.GetNamespace(), it),
 	}
 	var filteredActions []kubetesting.Action
 	for _, a := range shipperclientset.Actions() {
@@ -491,7 +507,11 @@ func TestManagementServerMissesCluster(t *testing.T) {
 		},
 	}
 	expectedActions := []kubetesting.Action{
-		kubetesting.NewUpdateAction(schema.GroupVersionResource{Resource: "installationtargets", Version: "v1alpha1", Group: "shipper.booking.com"}, release.GetNamespace(), it),
+		kubetesting.NewUpdateAction(schema.GroupVersionResource{
+			Resource: "installationtargets",
+			Version:  shipper.SchemeGroupVersion.Version,
+			Group:    shipper.SchemeGroupVersion.Group,
+		}, release.GetNamespace(), it),
 	}
 	var filteredActions []kubetesting.Action
 	for _, a := range shipperclientset.Actions() {

--- a/pkg/controller/installation/utils_test.go
+++ b/pkg/controller/installation/utils_test.go
@@ -259,7 +259,7 @@ func buildInstallationTargetWithOwner(ownerName, ownerUID, namespace, appName st
 			Namespace: namespace,
 			OwnerReferences: []v1.OwnerReference{
 				{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Release",
 					Name:       ownerName,
 					UID:        types.UID(ownerUID),

--- a/pkg/controller/schedulecontroller/scheduler.go
+++ b/pkg/controller/schedulecontroller/scheduler.go
@@ -489,7 +489,7 @@ func validateClusterRequirements(requirements shipper.ClusterRequirements) error
 // some potential context.
 func createOwnerRefFromRelease(r *shipper.Release) metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion: "shipper.booking.com/v1alpha1",
+		APIVersion: shipper.SchemeGroupVersion.String(),
 		Kind:       "Release",
 		Name:       r.GetName(),
 		UID:        r.GetUID(),

--- a/pkg/controller/schedulecontroller/scheduler_test.go
+++ b/pkg/controller/schedulecontroller/scheduler_test.go
@@ -28,7 +28,7 @@ func init() {
 func buildRelease() *shipper.Release {
 	return &shipper.Release{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "Release",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -37,7 +37,7 @@ func buildRelease() *shipper.Release {
 			Annotations: map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Application",
 					Name:       "test-application",
 				},
@@ -875,7 +875,7 @@ func generateReleaseForTestCase(reqs shipper.ClusterRequirements) *shipper.Relea
 			Namespace: shippertesting.TestNamespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Application",
 					Name:       "test-application",
 				},

--- a/pkg/controller/strategy/controller_test.go
+++ b/pkg/controller/strategy/controller_test.go
@@ -513,7 +513,7 @@ func (f *fixture) newController() (*Controller, shipperinformers.SharedInformerF
 	f.discovery = fakeDiscovery
 	f.discovery.Resources = []*metav1.APIResourceList{
 		{
-			GroupVersion: "shipper.booking.com/v1alpha1",
+			GroupVersion: shipper.SchemeGroupVersion.String(),
 			APIResources: []metav1.APIResource{
 				{
 					Kind:       "Application",

--- a/pkg/controller/strategy/executor_test.go
+++ b/pkg/controller/strategy/executor_test.go
@@ -202,7 +202,7 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 
 	rel := &shipper.Release{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "Release",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -210,7 +210,7 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Application",
 					Name:       app.GetName(),
 					UID:        app.GetUID(),
@@ -244,14 +244,14 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 
 	installationTarget := &shipper.InstallationTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "InstallationTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      incumbentName,
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,
@@ -272,14 +272,14 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 
 	capacityTarget := &shipper.CapacityTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "CapacityTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      incumbentName,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,
@@ -306,14 +306,14 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 
 	trafficTarget := &shipper.TrafficTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      incumbentName,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,
@@ -350,7 +350,7 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 func buildContender(totalReplicaCount uint) *releaseInfo {
 	rel := &shipper.Release{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "Release",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -358,7 +358,7 @@ func buildContender(totalReplicaCount uint) *releaseInfo {
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
-					APIVersion: "shipper.booking.com/v1alpha1",
+					APIVersion: shipper.SchemeGroupVersion.String(),
 					Kind:       "Application",
 					Name:       app.GetName(),
 					UID:        app.GetUID(),
@@ -387,14 +387,14 @@ func buildContender(totalReplicaCount uint) *releaseInfo {
 
 	installationTarget := &shipper.InstallationTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "InstallationTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      contenderName,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,
@@ -415,14 +415,14 @@ func buildContender(totalReplicaCount uint) *releaseInfo {
 
 	capacityTarget := &shipper.CapacityTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "CapacityTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      contenderName,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,
@@ -449,14 +449,14 @@ func buildContender(totalReplicaCount uint) *releaseInfo {
 
 	trafficTarget := &shipper.TrafficTarget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "shipper.booking.com/v1alpha1",
+			APIVersion: shipper.SchemeGroupVersion.String(),
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      contenderName,
 			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
-				APIVersion: "shipper.booking.com/v1alpha1",
+				APIVersion: shipper.SchemeGroupVersion.String(),
 				Name:       rel.Name,
 				Kind:       "Release",
 				UID:        rel.UID,

--- a/pkg/controller/strategy/strategy.go
+++ b/pkg/controller/strategy/strategy.go
@@ -31,19 +31,31 @@ func (c *CapacityTargetOutdatedResult) PatchSpec() (string, schema.GroupVersionK
 	patch := make(map[string]interface{})
 	patch["spec"] = c.NewSpec
 	b, _ := json.Marshal(patch)
-	return c.Name, schema.GroupVersionKind{Group: "shipper.booking.com", Version: "v1alpha1", Kind: "CapacityTarget"}, b
+	return c.Name, schema.GroupVersionKind{
+		Group:   shipper.SchemeGroupVersion.Group,
+		Version: shipper.SchemeGroupVersion.Version,
+		Kind:    "CapacityTarget",
+	}, b
 }
 
 func (c *TrafficTargetOutdatedResult) PatchSpec() (string, schema.GroupVersionKind, []byte) {
 	patch := make(map[string]interface{})
 	patch["spec"] = c.NewSpec
 	b, _ := json.Marshal(patch)
-	return c.Name, schema.GroupVersionKind{Group: "shipper.booking.com", Version: "v1alpha1", Kind: "TrafficTarget"}, b
+	return c.Name, schema.GroupVersionKind{
+		Group:   shipper.SchemeGroupVersion.Group,
+		Version: shipper.SchemeGroupVersion.Version,
+		Kind:    "TrafficTarget",
+	}, b
 }
 
 func (r *ReleaseUpdateResult) PatchSpec() (string, schema.GroupVersionKind, []byte) {
 	patch := make(map[string]interface{})
 	patch["status"] = r.NewStatus
 	b, _ := json.Marshal(patch)
-	return r.Name, schema.GroupVersionKind{Group: "shipper.booking.com", Version: "v1alpha1", Kind: "Release"}, b
+	return r.Name, schema.GroupVersionKind{
+		Group:   shipper.SchemeGroupVersion.Group,
+		Version: shipper.SchemeGroupVersion.Version,
+		Kind:    "Release",
+	}, b
 }


### PR DESCRIPTION
This replaces the various `shipper.booking.com/v1alpha` string literals with a const-style variable, `shipper.SchemeGroupVersion`.

Addresses one of Oleg's feedback points from #45 