### PR TITLE
e2e: don't hardcode test region

### DIFF
--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -12,7 +12,7 @@ go run cmd/create-cluster-secret/main.go --api-server http://127.0.0.1:8080
 go run cmd/shipper/*.go --kubeconfig ~/.kube/config --disable clustersecret --resync "$1" --log_dir /tmp &
 SHIPPER_PID=$!
 
-go test ./test/e2e --test.v --e2e --kubeconfig ~/.kube/config --testcharts $PWD/test/e2e/testdata/\*.tgz --progresstimeout=2m --targetcluster local
+go test ./test/e2e --test.v --e2e --kubeconfig ~/.kube/config --testcharts $PWD/test/e2e/testdata/\*.tgz --progresstimeout=2m --appcluster local
 TEST_STATUS=$?
 
 set +e


### PR DESCRIPTION
read it from the cluster object fetched by name

along the way, change 'target' to 'app' in cluster naming in E2E args