### PR TITLE
lint fixups

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -2,5 +2,6 @@
     "Vendor": true,
     "Enable": ["vet", "vetshadow", "ineffassign", "deadcode", "errcheck", "goconst", "staticcheck"],
     "Skip": ["pkg/client", "pkg/apis/shipper/v1alpha1"],
+    "Exclude": ["declaration of \"err\" shadows"],
     "Deadline": "300s"
 }

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,6 +1,6 @@
 {
     "Vendor": true,
-    "Enable": ["vet", "vetshadow", "ineffassign", "deadcode", "errcheck", "goconst", "megacheck"],
+    "Enable": ["vet", "vetshadow", "ineffassign", "deadcode", "errcheck", "goconst", "staticcheck"],
     "Skip": ["pkg/client", "pkg/apis/shipper/v1alpha1"],
     "Deadline": "300s"
 }

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -14,7 +14,7 @@ gometalinter \
     --enable=ineffassign \
     --enable=deadcode \
     --enable=goconst \
-    --enable=megacheck \
+    --enable=staticcheck \
     ./...
 
 go test -v $(go list ./... | grep -v /vendor/)

--- a/cmd/shipper-state-metrics/main.go
+++ b/cmd/shipper-state-metrics/main.go
@@ -116,7 +116,7 @@ func setupSignalHandler() <-chan struct{} {
 
 type glogStdLogger struct{}
 
-func (_ glogStdLogger) Println(v ...interface{}) {
+func (glogStdLogger) Println(v ...interface{}) {
 	// Prometheus only logs errors (which aren't fatal so we downgrade them to
 	// warnings).
 	glog.Warning(v...)

--- a/cmd/shipper-state-metrics/main.go
+++ b/cmd/shipper-state-metrics/main.go
@@ -92,7 +92,10 @@ func main() {
 				},
 			),
 		}
-		srv.ListenAndServe()
+		err := srv.ListenAndServe()
+		if err != nil {
+			glog.Fatalf("could not start /metrics endpoint: %s", err)
+		}
 	}()
 
 	<-stopCh

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -252,7 +252,10 @@ func runMetrics(cfg *metricsCfg) {
 			},
 		),
 	}
-	srv.ListenAndServe()
+	err := srv.ListenAndServe()
+	if err != nil {
+		glog.Fatalf("could not start /metrics endpoint: %s", err)
+	}
 }
 
 func buildEnabledControllers(enabledControllers, disabledControllers string) map[string]bool {

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -231,7 +231,7 @@ func main() {
 
 type glogStdLogger struct{}
 
-func (_ glogStdLogger) Println(v ...interface{}) {
+func (glogStdLogger) Println(v ...interface{}) {
 	// Prometheus only logs errors (which aren't fatal so we downgrade them to
 	// warnings).
 	glog.Warning(v...)

--- a/cmd/shipperctl/cmd/apply.go
+++ b/cmd/shipperctl/cmd/apply.go
@@ -41,11 +41,20 @@ const (
 )
 
 func init() {
-	applyCmd.Flags().StringVarP(&configFile, "file", "f", "clusters.yaml", "config file")
-	applyCmd.Flags().StringVar(&kubeConfigFile, "kube-config", "~/.kube/config", "the path to the Kubernetes configuration file")
+	fileFlagName := "file"
+	kubeConfigFlagName := "kube-config"
+	applyCmd.Flags().StringVarP(&configFile, fileFlagName, "f", "clusters.yaml", "config file")
+	applyCmd.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
 	applyCmd.Flags().StringVarP(&shipperSystemNamespace, "shipper-system-namespace", "n", shipper.ShipperNamespace, "the namespace where Shipper is running")
-	applyCmd.MarkFlagFilename("config", "yaml")
-	applyCmd.MarkFlagFilename("kube-config", "yaml")
+
+	err := applyCmd.MarkFlagFilename(fileFlagName, "yaml")
+	if err != nil {
+		applyCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", fileFlagName, err)
+	}
+	err = applyCmd.MarkFlagFilename(kubeConfigFlagName, "yaml")
+	if err != nil {
+		applyCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
+	}
 }
 
 func runApplyClustersCommand(cmd *cobra.Command, args []string) error {
@@ -384,7 +393,10 @@ func loadClustersConfiguration() (*config.ClustersConfiguration, error) {
 	}
 
 	configuration := &config.ClustersConfiguration{}
-	yaml.Unmarshal(configBytes, configuration)
+	err = yaml.Unmarshal(configBytes, configuration)
+	if err != nil {
+		return nil, err
+	}
 
 	return configuration, nil
 }

--- a/cmd/shipperctl/cmd/apply.go
+++ b/cmd/shipperctl/cmd/apply.go
@@ -360,7 +360,7 @@ func createApplicationClusterObjectOnManagementCluster(cmd *cobra.Command, manag
 	cmd.Printf("Creating or updating the cluster object for cluster %s on the management cluster... ", applicationCluster.Name)
 	// Doing a priliminary validation
 	if applicationCluster.Region == "" {
-		return fmt.Errorf("You must specify region for cluster %s", applicationCluster.Name)
+		return fmt.Errorf("must specify region for cluster %s", applicationCluster.Name)
 	}
 
 	// Initialize the map of capabilities if it's null so that we

--- a/pkg/chart/cache/cache.go
+++ b/pkg/chart/cache/cache.go
@@ -92,7 +92,7 @@ func (f *fsCache) Store(data []byte, repo, name, version string) error {
 
 	if overhead > 0 {
 		return fmt.Errorf(
-			"all known versions of %q deleted, but still over the size limit (overhead left: %d). yikes!",
+			"all known versions of %q deleted, but still over the size limit (overhead left: %d)",
 			familyPath, overhead,
 		)
 	}

--- a/pkg/clusterclientstore/queue.go
+++ b/pkg/clusterclientstore/queue.go
@@ -45,12 +45,12 @@ func (s *Store) bindEventHandlers() {
 				if !ok {
 					tombstone, ok := obj.(kubecache.DeletedFinalStateUnknown)
 					if !ok {
-						runtime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+						runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 						return
 					}
 					secret, ok = tombstone.Obj.(*corev1.Secret)
 					if !ok {
-						runtime.HandleError(fmt.Errorf("Tombstone contained object that is not a Secret %#v", obj))
+						runtime.HandleError(fmt.Errorf("tombstone contained object that is not a Secret %#v", obj))
 						return
 					}
 				}
@@ -70,12 +70,12 @@ func (s *Store) bindEventHandlers() {
 			if !ok {
 				tombstone, ok := obj.(kubecache.DeletedFinalStateUnknown)
 				if !ok {
-					runtime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+					runtime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 					return
 				}
 				cluster, ok = tombstone.Obj.(*shipper.Cluster)
 				if !ok {
-					runtime.HandleError(fmt.Errorf("Tombstone contained object that is not a Cluster %#v", obj))
+					runtime.HandleError(fmt.Errorf("tombstone contained object that is not a Cluster %#v", obj))
 					return
 				}
 			}

--- a/pkg/clusterclientstore/store.go
+++ b/pkg/clusterclientstore/store.go
@@ -224,7 +224,7 @@ func (s *Store) syncSecret(key string) error {
 
 	checksum, ok := secret.GetAnnotations()[shipper.SecretChecksumAnnotation]
 	if !ok {
-		return fmt.Errorf("Secret %q looks like a cluster secret but doesn't have a checksum", key)
+		return fmt.Errorf("secret %q looks like a cluster secret but doesn't have a checksum", key)
 	}
 
 	cachedCluster, ok := s.cache.Fetch(secret.Name)

--- a/pkg/controller/schedulecontroller/scheduler.go
+++ b/pkg/controller/schedulecontroller/scheduler.go
@@ -228,13 +228,13 @@ func (c *Scheduler) CreateInstallationTarget() error {
 	_, err := c.shipperclientset.ShipperV1alpha1().InstallationTargets(c.Release.Namespace).Create(installationTarget)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			installationTarget, listerErr := c.installationTargetLister.InstallationTargets(c.Release.Namespace).Get(c.Release.Name)
+			existingInstallationTarget, listerErr := c.installationTargetLister.InstallationTargets(c.Release.Namespace).Get(c.Release.Name)
 			if listerErr != nil {
 				glog.Errorf("Failed to fetch installation target: %s", listerErr)
 				return listerErr
 			}
 
-			for _, ownerRef := range installationTarget.GetOwnerReferences() {
+			for _, ownerRef := range existingInstallationTarget.GetOwnerReferences() {
 				if ownerRef.UID == c.Release.UID {
 					glog.Infof("InstallationTarget %q already exists but"+
 						" it belongs to current release, proceeding normally",
@@ -244,7 +244,7 @@ func (c *Scheduler) CreateInstallationTarget() error {
 			}
 
 			glog.Errorf("InstallationTarget %q already exists and it does not"+
-				" belong to the current release, bailing out", controller.MetaKey(installationTarget))
+				" belong to the current release, bailing out", controller.MetaKey(existingInstallationTarget))
 
 			return err
 		}
@@ -287,12 +287,12 @@ func (c *Scheduler) CreateCapacityTarget(totalReplicaCount int32) error {
 	_, err := c.shipperclientset.ShipperV1alpha1().CapacityTargets(c.Release.Namespace).Create(capacityTarget)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			capacityTarget, listerErr := c.capacityTargetLister.CapacityTargets(c.Release.Namespace).Get(c.Release.Name)
+			existingCapacityTarget, listerErr := c.capacityTargetLister.CapacityTargets(c.Release.Namespace).Get(c.Release.Name)
 			if listerErr != nil {
 				glog.Errorf("Failed to fetch capacity target: %s", listerErr)
 				return listerErr
 			}
-			for _, ownerRef := range capacityTarget.GetOwnerReferences() {
+			for _, ownerRef := range existingCapacityTarget.GetOwnerReferences() {
 				if ownerRef.UID == c.Release.UID {
 					glog.Infof("CapacityTarget %q already exists but"+
 						" it belongs to current release, proceeding normally",
@@ -301,7 +301,7 @@ func (c *Scheduler) CreateCapacityTarget(totalReplicaCount int32) error {
 				}
 			}
 			glog.Errorf("CapacityTarget %q already exists and it does not"+
-				" belong to the current release, bailing out", controller.MetaKey(capacityTarget))
+				" belong to the current release, bailing out", controller.MetaKey(existingCapacityTarget))
 
 			return err
 		}
@@ -344,12 +344,12 @@ func (c *Scheduler) CreateTrafficTarget() error {
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 
-			trafficTarget, listerErr := c.trafficTargetLister.TrafficTargets(c.Release.Namespace).Get(c.Release.Name)
+			existingTrafficTarget, listerErr := c.trafficTargetLister.TrafficTargets(c.Release.Namespace).Get(c.Release.Name)
 			if listerErr != nil {
 				glog.Errorf("Failed to fetch traffic target: %s", listerErr)
 				return listerErr
 			}
-			for _, ownerRef := range trafficTarget.GetOwnerReferences() {
+			for _, ownerRef := range existingTrafficTarget.GetOwnerReferences() {
 				if ownerRef.UID == c.Release.UID {
 					glog.Infof("TrafficTarget %q already exists but"+
 						" it belongs to current release, proceeding normally",
@@ -358,7 +358,7 @@ func (c *Scheduler) CreateTrafficTarget() error {
 				}
 			}
 			glog.Errorf("TrafficTarget %q already exists and it does not"+
-				" belong to the current release, bailing out", controller.MetaKey(trafficTarget))
+				" belong to the current release, bailing out", controller.MetaKey(existingTrafficTarget))
 
 			return err
 		}

--- a/pkg/controller/strategy/errors.go
+++ b/pkg/controller/strategy/errors.go
@@ -15,26 +15,26 @@ func IsNotWorkingOnStrategy(err error) bool {
 
 func NewNotWorkingOnStrategyError(contenderReleaseKey string) error {
 	return NotWorkingOnStrategyError(fmt.Errorf(
-		"Found %s as a contender, but it is not currently working on any strategy", contenderReleaseKey))
+		"found %s as a contender, but it is not currently working on any strategy", contenderReleaseKey))
 }
 
 type RetrievingInstallationTargetForReleaseError error
 
 func NewRetrievingInstallationTargetForReleaseError(releaseKey string, err error) RetrievingInstallationTargetForReleaseError {
 	return RetrievingInstallationTargetForReleaseError(fmt.Errorf(
-		"Error when retrieving installation target for release %s: %s", releaseKey, err))
+		"error when retrieving installation target for release %s: %s", releaseKey, err))
 }
 
 type RetrievingCapacityTargetForReleaseError error
 
 func NewRetrievingCapacityTargetForReleaseError(releasekey string, err error) RetrievingCapacityTargetForReleaseError {
 	return RetrievingCapacityTargetForReleaseError(fmt.Errorf(
-		"Error when retrieving capacity target for release %s: %s", releasekey, err))
+		"error when retrieving capacity target for release %s: %s", releasekey, err))
 }
 
 type RetrievingTrafficTargetForReleaseError error
 
 func NewRetrievingTrafficTargetForReleaseError(releaseKey string, err error) RetrievingTrafficTargetForReleaseError {
 	return RetrievingTrafficTargetForReleaseError(fmt.Errorf(
-		"Error when retrieving traffic target for release %s: %s", releaseKey, err))
+		"error when retrieving traffic target for release %s: %s", releaseKey, err))
 }

--- a/pkg/controller/traffic/errors.go
+++ b/pkg/controller/traffic/errors.go
@@ -2,7 +2,9 @@ package traffic
 
 import "fmt"
 
-type TargetClusterServiceError error
+type TargetClusterServiceError struct {
+	error
+}
 
 func NewTargetClusterFetchServiceFailedError(
 	clusterName string,
@@ -10,9 +12,9 @@ func NewTargetClusterFetchServiceFailedError(
 	namespace string,
 	err error,
 ) TargetClusterServiceError {
-	return TargetClusterServiceError(fmt.Errorf(
+	return TargetClusterServiceError{fmt.Errorf(
 		`cluster error (%q): failed to fetch Service matching %q in namespace %q: %s`,
-		clusterName, selector, namespace, err))
+		clusterName, selector, namespace, err)}
 }
 
 func NewTargetClusterWrongServiceCountError(
@@ -21,9 +23,9 @@ func NewTargetClusterWrongServiceCountError(
 	namespace string,
 	serviceCount int,
 ) TargetClusterServiceError {
-	return TargetClusterServiceError(fmt.Errorf(
+	return TargetClusterServiceError{fmt.Errorf(
 		"cluster error (%q): expected exactly one Service in namespace %q matching %q, but got %d",
-		clusterName, namespace, selector, serviceCount))
+		clusterName, namespace, selector, serviceCount)}
 }
 
 func NewTargetClusterServiceMissesSelectorError(
@@ -31,12 +33,12 @@ func NewTargetClusterServiceMissesSelectorError(
 	namespace string,
 	serviceName string,
 ) TargetClusterServiceError {
-	return TargetClusterServiceError(fmt.Errorf(
+	return TargetClusterServiceError{fmt.Errorf(
 		"cluster error (%q): service %s/%s does not have a selector set. this means we cannot do label-based canary deployment",
-		clusterName, namespace, serviceName))
+		clusterName, namespace, serviceName)}
 }
 
-type TargetClusterTrafficError error
+type TargetClusterTrafficError struct{ error }
 
 func NewTargetClusterTrafficModifyingLabelError(
 	clusterName string,
@@ -44,21 +46,21 @@ func NewTargetClusterTrafficModifyingLabelError(
 	podName string,
 	err error,
 ) TargetClusterTrafficError {
-	return TargetClusterTrafficError(fmt.Errorf(
+	return TargetClusterTrafficError{fmt.Errorf(
 		"pod error (%s/%s/%s): failed to add traffic label: %q",
-		clusterName, namespace, podName, err.Error()))
+		clusterName, namespace, podName, err.Error())}
 }
 
-type TargetClusterPodListingError error
+type TargetClusterPodListingError struct{ error }
 
 func NewTargetClusterPodListingError(
 	clusterName string,
 	namespace string,
 	err error,
 ) TargetClusterPodListingError {
-	return TargetClusterPodListingError(fmt.Errorf(
+	return TargetClusterPodListingError{fmt.Errorf(
 		"cluster error (%q): failed to list pods in '%s': %q",
-		clusterName, namespace, err.Error()))
+		clusterName, namespace, err.Error())}
 }
 
 func NewTargetClusterReleasePodListingError(
@@ -67,21 +69,21 @@ func NewTargetClusterReleasePodListingError(
 	namespace string,
 	err error,
 ) TargetClusterPodListingError {
-	return TargetClusterPodListingError(fmt.Errorf(
+	return TargetClusterPodListingError{fmt.Errorf(
 		"release error (%q): failed to list pods in '%s/%s': %q",
-		releaseName, clusterName, namespace, err.Error()))
+		releaseName, clusterName, namespace, err.Error())}
 }
 
-type TargetClusterMathError error
+type TargetClusterMathError struct{ error }
 
 func NewTargetClusterMathError(
 	releaseName string,
 	idlePodCount int,
 	missingCount int,
 ) TargetClusterMathError {
-	return TargetClusterMathError(fmt.Errorf(
+	return TargetClusterMathError{fmt.Errorf(
 		"release error (%q): the math is broken: there aren't enough idle pods (%d) to meet requested increase in traffic pods (%d)",
 		releaseName,
 		idlePodCount,
-		missingCount))
+		missingCount)}
 }

--- a/pkg/controller/traffic/pod_label_shifter.go
+++ b/pkg/controller/traffic/pod_label_shifter.go
@@ -52,7 +52,7 @@ func newPodLabelShifter(
 
 func (p *podLabelShifter) Clusters() []string {
 	clusters := make([]string, 0, len(p.clusterReleaseWeights))
-	for cluster, _ := range p.clusterReleaseWeights {
+	for cluster := range p.clusterReleaseWeights {
 		clusters = append(clusters, cluster)
 	}
 	sort.Strings(clusters)

--- a/pkg/controller/traffic/pod_label_shifter.go
+++ b/pkg/controller/traffic/pod_label_shifter.go
@@ -283,14 +283,14 @@ func buildClusterReleaseWeights(trafficTargets []*shipper.TrafficTarget) (cluste
 		release, ok := tt.Labels[shipper.ReleaseLabel]
 		if !ok {
 			return nil, fmt.Errorf(
-				"TrafficTarget '%s/%s' needs a 'release' label in order to select resources in the target clusters.",
+				"trafficTarget '%s/%s' needs a 'release' label in order to select resources in the target clusters",
 				tt.Namespace, tt.Name,
 			)
 		}
 		existingTT, ok := releaseTT[release]
 		if ok {
 			return nil, fmt.Errorf(
-				"TrafficTargets %q and %q in namespace %q both operate on release %q. This is wrong, please fix",
+				"trafficTargets %q and %q in namespace %q both operate on release %q",
 				existingTT.Name, tt.Name, tt.Namespace, release,
 			)
 		}


### PR DESCRIPTION
`megacheck` was merged into `staticcheck`, and `staticcheck` got a few new checks (like @ksurent's excellent 'unreachable case statement' checker). This PR cleans all the lint failures (and tweaks the linter config) so that `gometalinter ./...` runs cleanly. No functional changes.