### PR TITLE
Print additional columns for Release objects

### DIFF
--- a/crd/Release-crd.yaml
+++ b/crd/Release-crd.yaml
@@ -4,6 +4,17 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: releases.shipper.booking.com
 spec:
+  # additional columns to print for kubectl get command besides NAME and AGE
+  # and NAMESPACE (in case of passing --all-namespaces flag)
+  additionalPrinterColumns:
+  - JSONPath: .metadata.annotations.shipper\.booking\.com\/release\.clusters
+    description: The list of clusters where a release is supposed to be rolled out as per strategy.
+    name: Clusters
+    type: string
+  - JSONPath: .status.achievedStep.name
+    description: The current achieved step for a release as defined in the rollout strategy.
+    name: Step
+    type: string
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/pkg/crds/release.go
+++ b/pkg/crds/release.go
@@ -45,5 +45,19 @@ var Release = &apiextensionv1beta1.CustomResourceDefinition{
 				},
 			},
 		},
+		AdditionalPrinterColumns: []apiextensionv1beta1.CustomResourceColumnDefinition{
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Clusters",
+				Type:        "string",
+				Description: "The list of clusters where a release is supposed to be rolled out as per strategy.",
+				JSONPath:    ".metadata.annotations.shipper\\.booking\\.com\\/release\\.clusters",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Step",
+				Type:        "string",
+				Description: "The current achieved step for a release as defined in the rollout strategy.",
+				JSONPath:    ".status.achievedStep.name",
+			},
+		},
 	},
 }


### PR DESCRIPTION
When doing a `kubectl get releases`, we can now show additional columns
with more useful information about the Release, namely the clusters it
was deployed to, and which step the release is currently in.

Output will now look like this:

```
NAME                         CLUSTERS                STEP      AGE
frontend-3bb976cc-0          eu-north-n2             full on   14h
backend-3c678546-0           eu-north-n1             staging   4d
```

This would be really handy with --watch flag and also will save some
scripting from user point of view.

Fixes #67.