### PR TITLE
controllers: don't retry unrecoverable k8s API errors

### DIFF
--- a/pkg/controller/capacity/capacity_controller.go
+++ b/pkg/controller/capacity/capacity_controller.go
@@ -270,8 +270,9 @@ func (c *Controller) capacityTargetSyncHandler(key string) bool {
 
 	_, err = c.shipperclientset.ShipperV1alpha1().CapacityTargets(namespace).Update(ct)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("error syncing CapacityTarget %q (will retry): %s", key, err))
-		return true
+		shouldRetry := !kerrors.IsInvalid(err)
+		runtime.HandleError(fmt.Errorf("error syncing CapacityTargets %q (will retry: %t): %s", key, shouldRetry, err))
+		return shouldRetry
 	}
 
 	return false

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -185,7 +185,8 @@ func (c *Controller) syncOne(key string) bool {
 	}
 
 	if err := c.processInstallation(it.DeepCopy()); err != nil {
-		shouldRetry := !shippercontroller.IsMultipleOwnerReferencesError(err) &&
+		shouldRetry := !kerrors.IsInvalid(err) &&
+			!shippercontroller.IsMultipleOwnerReferencesError(err) &&
 			!shippercontroller.IsWrongOwnerReferenceError(err) &&
 			!IsIncompleteReleaseError(err)
 

--- a/pkg/controller/schedulecontroller/errors.go
+++ b/pkg/controller/schedulecontroller/errors.go
@@ -2,6 +2,7 @@ package schedulecontroller
 
 import (
 	"fmt"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 )
 
@@ -33,7 +34,7 @@ func classifyError(err error) (string, bool) {
 		return "InvalidReleaseOwnerRefs", noRetry
 
 	case FailedAPICallError:
-		return "FailedAPICall", retry
+		return "FailedAPICall", !kerrors.IsInvalid(err)
 	}
 
 	return "unknown error! tell Shipper devs to classify it", retry

--- a/pkg/controller/traffic/traffic_controller.go
+++ b/pkg/controller/traffic/traffic_controller.go
@@ -358,8 +358,9 @@ func (c *Controller) syncHandler(key string) bool {
 
 	_, err = c.shipperclientset.ShipperV1alpha1().TrafficTargets(namespace).Update(ttCopy)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("error syncing TrafficTarget %q (will retry): %s", key, err))
-		return true
+		shouldRetry := !kerrors.IsInvalid(err)
+		runtime.HandleError(fmt.Errorf("error syncing TrafficTarget %q (will retry: %t): %s", key, shouldRetry, err))
+		return shouldRetry
 	}
 
 	// TODO(btyler): don't record "success" if it wasn't a total success: this


### PR DESCRIPTION
It is possible that a write to an object in kubernetes can make it
inherently invalid. For instance, exceeding etcd's 1MB storage limit. In
this case, there is no point to retrying over and over again, since
it'll never recover. Also, having unrecoverable retries clogs the
working queues, preventing more useful work from being done, and also
makes unnecessary requests to the k8s API, making us hit our API request
throttling limit.

Here, we're considering that any .Create() or .Update() that results in
an HTTP 422 "Unprocessable Entity" error is unrecoverable. We can check
that by calling kerrors.IsInvalid(err).

Closes #15 