### PR TITLE
Include "Age" when printing releases

### DIFF
--- a/crd/Release-crd.yaml
+++ b/crd/Release-crd.yaml
@@ -15,6 +15,10 @@ spec:
     description: The current achieved step for a release as defined in the rollout strategy.
     name: Step
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The release's age.
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/pkg/crds/release.go
+++ b/pkg/crds/release.go
@@ -58,6 +58,12 @@ var Release = &apiextensionv1beta1.CustomResourceDefinition{
 				Description: "The current achieved step for a release as defined in the rollout strategy.",
 				JSONPath:    ".status.achievedStep.name",
 			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Age",
+				Type:        "date",
+				Description: "The release's age.",
+				JSONPath:    ".metadata.creationTimestamp",
+			},
 		},
 	},
 }


### PR DESCRIPTION
In PR #80, we tried to make the output of `kubectl get release` more
useful by including additional columns. Unfortunately, we nuked the
"Age" column when we didn't want to. As users use that to find out
what's the latest release for an application, we ended up making the
output *less* useful.

It turns out that, when adding additional columns, they replace *all*
the previously available columns (in this case, just the age).
Explicitly including it fixes the problem.