### PR TITLE
shipper-state-metrics: calculate the right percentiles

### DIFF
--- a/cmd/shipper-state-metrics/collector.go
+++ b/cmd/shipper-state-metrics/collector.go
@@ -170,9 +170,10 @@ func (ssm ShipperStateMetrics) collectReleases(ch chan<- prometheus.Metric) {
 
 		if rel.Status.Strategy != nil {
 			for _, condition := range rel.Status.Strategy.Conditions {
-				if condition.Status == corev1.ConditionFalse {
+				if condition.Status != corev1.ConditionFalse {
 					continue
 				}
+
 				age := now.Sub(condition.LastTransitionTime.Time).Seconds()
 				relAgesByCondition[string(condition.Type)] = append(relAgesByCondition[string(condition.Type)], age)
 			}

--- a/cmd/shipper-state-metrics/math.go
+++ b/cmd/shipper-state-metrics/math.go
@@ -47,7 +47,7 @@ func MakeSummary(input []float64, quantiles []float64) (map[float64]float64, err
 	summary := make(map[float64]float64)
 
 	for _, p := range quantiles {
-		percentile, err := Percentile(input, p)
+		percentile, err := Percentile(input, p*100)
 		summary[p] = percentile
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- It's helpful to get metrics of the right things. We're interested in
the age of releases with *False* conditions, since they're the ones that
are currently waiting for installation/capacity/target, and we wanna
know for how long that is. Before, we were calculating the age of
releases that were not waiting on the thing anymore.

- Calculate the percentiles right. Percentile expects a percentage, but
we were passing it as percentage/100, which is what prometheus expects.
Unitless numbers are hard.