### PR TITLE
shipper-state-metrics: ignore duration of complete releases

### DIFF
--- a/cmd/shipper-state-metrics/collector.go
+++ b/cmd/shipper-state-metrics/collector.go
@@ -13,6 +13,7 @@ import (
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shipperlisters "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
+	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 )
 
 var (
@@ -168,7 +169,12 @@ func (ssm ShipperStateMetrics) collectReleases(ch chan<- prometheus.Metric) {
 			}
 		}
 
-		if rel.Status.Strategy != nil {
+		// We're only interested in incomplete releases, as this metric
+		// is intended to for measuring how long each release takes to
+		// roll out, waiting for installation, capacity and traffic.
+		// Sometimes, previously completed releases lose capacity and
+		// don't recover, and we're not interested in those.
+		if !releaseutil.ReleaseComplete(rel) && rel.Status.Strategy != nil {
 			for _, condition := range rel.Status.Strategy.Conditions {
 				if condition.Status != corev1.ConditionFalse {
 					continue


### PR DESCRIPTION
shipper_objects_release_durations is intended for measuring how long a
release currently being rolled out spends waiting for installation,
capacity and traffic. Sometimes, fully rolled out releases end up losing
capacity for whatever reason, and they tend to dominate the metrics in
larger shipper installations.

This does not completely solve the problem of releases taking an
inordinate amount of time (days, weeks, years even!) when they're
hopelessly broken, but at least we're now only reporting on things that
haven't completed in the past.