### PR TITLE
validating webhook: validate only create/update

### DIFF
--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -424,7 +424,8 @@ func (c *Cluster) CreateValidatingWebhookConfiguration(caBundle []byte, namespac
 				Rules: []admissionregistrationv1beta1.RuleWithOperations{
 					admissionregistrationv1beta1.RuleWithOperations{
 						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.OperationAll,
+							admissionregistrationv1beta1.Create,
+							admissionregistrationv1beta1.Update,
 						},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{shipper.SchemeGroupVersion.Group},


### PR DESCRIPTION
We're not interested in validating deletes at this point. Additionally,
the webhook code doesn't currently handle those very well, failing with:

```
Error from server: admission webhook "shipper.booking.com"
denied the request: unexpected end of JSON input
```