### PR TITLE
Disabled commit-based image building process

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -17,16 +17,14 @@ if [ "$TRAVIS_SECURE_ENV_VARS" != "true" ]; then
     exit 1
 fi
 
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-
-docker build -t bookingcom/shipper:$TRAVIS_COMMIT -f Dockerfile.shipper .
-docker push bookingcom/shipper:$TRAVIS_COMMIT
-
-docker build -t bookingcom/shipper-state-metrics:$TRAVIS_COMMIT -f Dockerfile.shipper-state-metrics .
-docker push bookingcom/shipper-state-metrics:$TRAVIS_COMMIT
-
-# building a tagged release
+# building a tagged release only
 if [ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]; then
+
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+    docker build -t bookingcom/shipper:$TRAVIS_COMMIT -f Dockerfile.shipper .
+    docker build -t bookingcom/shipper-state-metrics:$TRAVIS_COMMIT -f Dockerfile.shipper-state-metrics .
+
     docker tag bookingcom/shipper-state-metrics:$TRAVIS_COMMIT bookingcom/shipper-state-metrics:$TRAVIS_TAG
     docker push bookingcom/shipper-state-metrics:$TRAVIS_TAG
 


### PR DESCRIPTION
This commit disables docker image building for any commit but
release-tagged ones. Since Shipper has transitioned to semver release
branching and doesn't provide any guarentees around a random commit in
the master branch, we are disabling image building based on non-tagged
commits.