### PR TITLE
Bumped copyright year in the docs template footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 import sphinx_rtd_theme
 
 project = u'shipper'
-copyright = u'2018, Booking.com'
+copyright = u'2019, Booking.com'
 
 source_suffix = '.rst'
 


### PR DESCRIPTION
In this minor PR we bump the current year so the docs templates get updated