### PR TITLE
Updating e2e README file

### DIFF
--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -12,7 +12,7 @@ kubectl wait -n container-registry --for=condition=ready pod/$REGISTRY_POD
 
 # Build an image with the test charts and deploy it
 HELM_IMAGE=localhost:32000/bookingcom/shipper-helm:latest make helm
-sed s=\<HELM_IMAGE\>=localhost:32000/bookingcom/shipper:latest= ci/helm.yaml | \
+sed s=\<HELM_IMAGE\>=localhost:32000/bookingcom/shipper-helm:latest= ci/helm.yaml | \
 	kubectl apply -f -
 
 # Build an image with shipper and deploy it

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -12,7 +12,8 @@ kubectl wait -n container-registry --for=condition=ready pod/$REGISTRY_POD
 
 # Build an image with the test charts and deploy it
 HELM_IMAGE=localhost:32000/bookingcom/shipper-helm:latest make helm
-kubectl apply -f ci/helm.yaml
+sed s=\<HELM_IMAGE\>=localhost:32000/bookingcom/shipper:latest= ci/helm.yaml | \
+	kubectl apply -f -
 
 # Build an image with shipper and deploy it
 SHIPPER_IMAGE=localhost:32000/bookingcom/shipper:latest make shipper

--- a/ci/helm.yaml
+++ b/ci/helm.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: localhost:32000/bookingcom/shipper-helm:latest
+          image: <HELM_IMAGE>
           env:
             - name: POD_IP
               valueFrom:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,29 +5,39 @@
 These tests assume that they can reach a properly configured Kubernetes cluster
 that has Shipper running on it. To setup microk8s into this condition, do
 the following:
-
+* If you don't have a `container-registry` namespace, run `microk8s.enable registry` in your microk8s
 * In microk8s open file `/var/snap/microk8s/current/args/kube-apiserver`. Look for `--insecure-port=XXXX` (for example 8080)
-* In you computer `kubectl config view`. Look for microk8s-cluster, and make sure that the server port is the __insecure__ port from your microk8s (and not the __secure__ port)!
+* In you computer `kubectl config view`. Look for microk8s-cluster, and make sure that the server 
+port is the __insecure__ port from your microk8s (and not the __secure__ port)!
 * Disable proxys should help
 * Make sure you're using microk8s context (`kubectl config use-context microk8s`)
-* `perl hack/install-crds.pl`
-* Use shipperctl to configure clusters.
-    clusters.yaml file should look like:
+* Use shipperctl to configure clusters: `go run cmd/shipperctl/main.go admin clusters apply -f ci/clusters.yaml`
+* Wait for microk8s.registry to be ready, as we're about to use it
     ```
-    managementClusters:
-    - name: microk8s
-    applicationClusters:
-    - name: microk8s
-    region: local
+    REGISTRY_POD=$(kubectl get pod -n container-registry -l app=registry -o jsonpath='{.items[0].metadata.name}')
+    kubectl wait -n container-registry --for=condition=ready pod/$REGISTRY_POD
     ```
-    and then `shipperctl admin clusters apply -f clusters.yaml`
-* In the background or a different shell run shipper locally `go run cmd/shipper/main.go --logtostderr --kubeconfig ~/.kube/config -v 4 -disable clustersecret`
-    Leave this running
+* Build an image with the test charts and deploy it:
+    ```
+    HELM_IMAGE=$REGISTRY/shipper-helm:latest make helm
+    sed s=\<HELM_IMAGE\>=$REGISTRY/shipper-helm:latest= ci/helm.yaml | \
+    kubectl apply -f -
+    ```
+    * replace `$REGISTRY` with the proper image registry. You can use `localhost:32000` if you're 
+    running in you microk8s, `MICROK8S-IP:MICROK8S-PORT` if you're running shipper locally, 
+    or use a public registry like docker-registry.
+* Build an image with shipper and deploy it (again, replace `$REGISTRY`): 
+    ```
+    SHIPPER_IMAGE=$REGISTRY/shipper:latest make shipper
+    sed s=\<IMAGE\>=$REGISTRY/shipper:latest= kubernetes/shipper.deployment.yaml | \
+    kubectl create -f -
+    ```
 
-Once you have a working cluster, you can run the e2e tests like so:
+Once you have a working cluster (and shipper pod has a 'ready' condition), you can run the e2e tests like so:
 
 ```
-go test ./test/e2e -kubeconfig ~/.kube/config -e2e -appcluster microk8s -v
+TESTCHARTS=http://$(kubectl get pod -l app=helm -o jsonpath='{.items[0].status.podIP}'):8879
+go test ./test/e2e --test.v --e2e --kubeconfig ~/.kube/config --testcharts $TESTCHARTS --progresstimeout=2m --appcluster microk8s
 ```
 
 Alternatively, if you'd like to use the e2e tests as part of your development

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,18 +3,31 @@
 ## Setup
 
 These tests assume that they can reach a properly configured Kubernetes cluster
-that has Shipper running on it. To get a fresh minikube into this condition, do
+that has Shipper running on it. To setup microk8s into this condition, do
 the following:
 
-* `minikube start`
+* In microk8s open file `/var/snap/microk8s/current/args/kube-apiserver`. Look for `--insecure-port=XXXX` (for example 8080)
+* In you computer `kubectl config view`. Look for microk8s-cluster, and make sure that the server port is the __insecure__ port from your microk8s (and not the __secure__ port)!
+* Disable proxys should help
+* Make sure you're using microk8s context (`kubectl config use-context microk8s`)
 * `perl hack/install-crds.pl`
-* `perl hack/create-minikube-cluster-secret.pl`: this creates a secret and cluster object on the minikube that point to itself.
-* In the background or a different shell: `go run cmd/shipper/main.go --logtostderr --kubeconfig ~/.kube/config -v 4 --disable clustersecret`
+* Use shipperctl to configure clusters.
+    clusters.yaml file should look like:
+    ```
+    managementClusters:
+    - name: microk8s
+    applicationClusters:
+    - name: microk8s
+    region: local
+    ```
+    and then `shipperctl admin clusters apply -f clusters.yaml`
+* In the background or a different shell run shipper locally `go run cmd/shipper/main.go --logtostderr --kubeconfig ~/.kube/config -v 4 -disable clustersecret`
+    Leave this running
 
 Once you have a working cluster, you can run the e2e tests like so:
 
 ```
-go test ./test/e2e -kubeconfig ~/.kube/config -e2e`
+go test ./test/e2e -kubeconfig ~/.kube/config -e2e -appcluster microk8s -v
 ```
 
 Alternatively, if you'd like to use the e2e tests as part of your development


### PR DESCRIPTION
previous readme file was instructing to use minikube, and had minimal instructions on how to run e2e tests.
While trying to run e2e tests locally, with the help of the team, I curated some tips to setup environment correctly in order to update this file.
This change include checking clusters server port in the config file, a tip to disable proxys and using helm image.