### PR TITLE
Rate limiting the release objects that on update are unchanged

### DIFF
--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -135,9 +135,17 @@ func NewController(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: controller.enqueueRelease,
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oldRel, oldOk := oldObj.(*shipper.Release)
-				newRel, newOk := newObj.(*shipper.Release)
-				if oldOk && newOk && oldRel.GetResourceVersion() == newRel.GetResourceVersion() {
+				oldRel, ok := oldObj.(*shipper.Release)
+				if !ok {
+					return
+				}
+
+				newRel, ok := newObj.(*shipper.Release)
+				if !ok {
+					return
+				}
+
+				if oldRel.GetResourceVersion() == newRel.GetResourceVersion() {
 					controller.enqueueReleaseRateLimited(newObj)
 					return
 				}

--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -135,17 +135,9 @@ func NewController(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: controller.enqueueRelease,
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oldRel, ok := oldObj.(shipper.Release)
-				if !ok {
-					return
-				}
-
-				newRel, ok := newObj.(shipper.Release)
-				if !ok {
-					return
-				}
-
-				if oldRel.GetResourceVersion() == newRel.GetResourceVersion() {
+				oldRel, oldOk := oldObj.(*shipper.Release)
+				newRel, newOk := newObj.(*shipper.Release)
+				if oldOk && newOk && oldRel.GetResourceVersion() == newRel.GetResourceVersion() {
 					controller.enqueueReleaseRateLimited(newObj)
 					return
 				}


### PR DESCRIPTION
Addressing the spike on resyncs, rate limiting the release objects that on update are unchanged.

We want to space out release objects over the time between resyncs. We want to do that only for release objects that are unchanged, in order to not introduce latency to updating release object that require an update.