### PR TITLE
Make `helm serve` listen on POD_IP

### DIFF
--- a/Dockerfile.helm
+++ b/Dockerfile.helm
@@ -2,4 +2,4 @@ FROM alpine/helm:2.13.1
 
 ADD test/e2e/testdata /charts
 
-ENTRYPOINT ["helm", "serve", "--repo-path", "/charts", "--address", "0.0.0.0:8879"]
+ENTRYPOINT helm serve --repo-path /charts --address $POD_IP:8879

--- a/ci/helm.yaml
+++ b/ci/helm.yaml
@@ -15,5 +15,9 @@ spec:
       containers:
         - name: app
           image: localhost:32000/bookingcom/shipper-helm:latest
-          args: ["serve", ""]
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
 


### PR DESCRIPTION
This is a regression introduced by #86 when it was merged after
a20ba0141ad104759f2d4176147d7138f30455b8. Although we can reach the helm
server when it listens on 0.0.0.0, it takes that address to build
absolute URLs when serving chart catalogs. To solve that, we need to
inject the pod IP, and have `helm server` listen there.