### PR TITLE
Reading ApiMaster From Shipperctl Config

### DIFF
--- a/cmd/shipperctl/cmd/apply.go
+++ b/cmd/shipperctl/cmd/apply.go
@@ -194,7 +194,11 @@ func joinClusters(managementCluster, applicationCluster *config.ClusterConfigura
 		return err
 	}
 
-	if err := createApplicationClusterObjectOnManagementCluster(cmd, managementClusterConfigurator, applicationCluster, applicationClusterConfigurator.Host); err != nil {
+	if applicationCluster.APIMaster == "" {
+		applicationCluster.APIMaster = applicationClusterConfigurator.Host
+	}
+
+	if err := createApplicationClusterObjectOnManagementCluster(cmd, managementClusterConfigurator, applicationCluster); err != nil {
 		return err
 	}
 
@@ -502,7 +506,7 @@ func copySecretFromApplicationToManagementCluster(cmd *cobra.Command, applicatio
 	return nil
 }
 
-func createApplicationClusterObjectOnManagementCluster(cmd *cobra.Command, managementClusterConfigurator *configurator.Cluster, applicationCluster *config.ClusterConfiguration, host string) error {
+func createApplicationClusterObjectOnManagementCluster(cmd *cobra.Command, managementClusterConfigurator *configurator.Cluster, applicationCluster *config.ClusterConfiguration) error {
 	cmd.Printf("Creating or updating the cluster object for cluster %s on the management cluster... ", applicationCluster.Name)
 
 	// Initialize the map of capabilities if it's null so that we
@@ -510,7 +514,7 @@ func createApplicationClusterObjectOnManagementCluster(cmd *cobra.Command, manag
 	if applicationCluster.Capabilities == nil {
 		applicationCluster.Capabilities = []string{}
 	}
-	if err := managementClusterConfigurator.CreateOrUpdateClusterWithConfig(applicationCluster, host); err != nil {
+	if err := managementClusterConfigurator.CreateOrUpdateClusterWithConfig(applicationCluster); err != nil {
 		return err
 	}
 	cmd.Println("done")

--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -195,23 +195,22 @@ func (c *Cluster) CopySecret(cluster *shipper.Cluster, newNamespace string, secr
 	return err
 }
 
-func (c *Cluster) CreateOrUpdateClusterWithConfig(configuration *config.ClusterConfiguration, host string) error {
+func (c *Cluster) CreateOrUpdateClusterWithConfig(configuration *config.ClusterConfiguration) error {
 	existingCluster, err := c.ShipperClient.ShipperV1alpha1().Clusters().Get(configuration.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return c.CreateClusterFromConfig(configuration, host)
+			return c.CreateClusterFromConfig(configuration)
 		} else {
 			return err
 		}
 	}
 
 	existingCluster.Spec = configuration.ClusterSpec
-	existingCluster.Spec.APIMaster = host
 	_, err = c.ShipperClient.ShipperV1alpha1().Clusters().Update(existingCluster)
 	return err
 }
 
-func (c *Cluster) CreateClusterFromConfig(configuration *config.ClusterConfiguration, host string) error {
+func (c *Cluster) CreateClusterFromConfig(configuration *config.ClusterConfiguration) error {
 	cluster := &shipper.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configuration.Name,
@@ -219,7 +218,6 @@ func (c *Cluster) CreateClusterFromConfig(configuration *config.ClusterConfigura
 		Spec: configuration.ClusterSpec,
 	}
 
-	cluster.Spec.APIMaster = host
 	_, err := c.ShipperClient.ShipperV1alpha1().Clusters().Create(cluster)
 	return err
 }


### PR DESCRIPTION
Previously, even though one could specify `apiMaster` in the
shipperctl configuration, the `host` which was retrieved from the
Kubernetes configuration which is by default `~/.kube/config` would
override it. This meant that effectively, there was no way to specify
an apimaster other than that in the kubernetes configuration. The
side-effect of this was that when attempting to run shipperctl on the
Kubernetes cluster created by Docker for Desktop, you had to always
manually go and modify the Cluster object after every single time you
ran `shipperctl admin clusters apply -f clusters.yaml`.

This small patch changes this so that the `apimaster` specified in the
shipperctl configuration file takes priority.