### PR TITLE
Add an unrecoverable error for no chart repo

### DIFF
--- a/pkg/chart/repo/handlers.go
+++ b/pkg/chart/repo/handlers.go
@@ -22,6 +22,9 @@ func ResolveChartVersionFunc(c *Catalog) ChartVersionResolver {
 
 		if _, err := repo.RefreshIndex(); err != nil {
 			glog.Warningf("failed to refresh repo[%s] index: %s", chartspec.RepoURL, err)
+			if len(c.repos) == 1 {
+				return nil, errors.NewUnrecoverableChartFetchFailureError(chartspec, err)
+			}
 		}
 
 		return repo.ResolveVersion(chartspec)

--- a/pkg/errors/chart.go
+++ b/pkg/errors/chart.go
@@ -22,6 +22,29 @@ func newChartError(chartspec *shipper.Chart) ChartError {
 	}
 }
 
+type UnrecoverableChartFetchFailureError struct {
+	ChartError
+	err error
+}
+
+func (e UnrecoverableChartFetchFailureError) Error() string {
+	return fmt.Sprintf(
+		"failed to fetch chart [name: %q, version: %q, repo: %q]: %s",
+		e.chartName, e.chartVersion, e.chartRepo,
+		e.err)
+}
+
+func (e UnrecoverableChartFetchFailureError) ShouldRetry() bool {
+	return false
+}
+
+func NewUnrecoverableChartFetchFailureError(chartspec *shipper.Chart, err error) UnrecoverableChartFetchFailureError {
+	return UnrecoverableChartFetchFailureError{
+		ChartError: newChartError(chartspec),
+		err:        err,
+	}
+}
+
 type ChartFetchFailureError struct {
 	ChartError
 	err error


### PR DESCRIPTION
Add an unrecoverable error for no chart repo

This error will be used when we failed to fetch chart repo, and there's no previous index for fallback