### PR TITLE
Give more information for errors of failed chart repo index

### DIFF
--- a/pkg/errors/chart.go
+++ b/pkg/errors/chart.go
@@ -189,6 +189,25 @@ func NewChartDataCorruptionError(cv *repo.ChartVersion, err error) ChartDataCorr
 	}
 }
 
+type NoCachedChartRepoIndexError struct {
+	err error
+}
+
+func (e NoCachedChartRepoIndexError) Error() string {
+	return fmt.Sprintf(
+		"failed to get chart repo index and there is no index in cache: %s",
+		e.err,
+	)
+}
+
+func (e NoCachedChartRepoIndexError) ShouldRetry() bool {
+	return true
+}
+
+func NewNoCachedChartRepoIndexError(err error) NoCachedChartRepoIndexError {
+	return NoCachedChartRepoIndexError{err: err}
+}
+
 type ChartRepoIndexError struct {
 	err error
 }


### PR DESCRIPTION
Add an error for no chart repo to give more information to the user
This error will be used when we failed to fetch chart repo, and there's no previous index in cache for fallback

