### PR TITLE
Define better printing Columns for Shipper CRDs

### DIFF
--- a/crd/Application-crd.yaml
+++ b/crd/Application-crd.yaml
@@ -4,6 +4,19 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: applications.shipper.booking.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.history[-1]
+    description: The application's latest release.
+    name: Latest release
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="RollingOut")].status
+    description: Whether the application is going through a rollout.
+    name: Rolling Out
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The applications's age.
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/crd/Release-crd.yaml
+++ b/crd/Release-crd.yaml
@@ -7,18 +7,23 @@ spec:
   # additional columns to print for kubectl get command besides NAME and AGE
   # and NAMESPACE (in case of passing --all-namespaces flag)
   additionalPrinterColumns:
-  - JSONPath: .metadata.annotations.shipper\.booking\.com\/release\.clusters
-    description: The list of clusters where a release is supposed to be rolled out as per strategy.
-    name: Clusters
-    type: string
   - JSONPath: .status.achievedStep.name
     description: The current achieved step for a release as defined in the rollout strategy.
     name: Step
+    type: string
+  - JSONPath: .status.conditions[?(@.status=="False")].reason
+    description: Errors from False conditions that show what's wrong with the release.
+    name: Errors
     type: string
   - JSONPath: .metadata.creationTimestamp
     description: The release's age.
     name: Age
     type: date
+  - JSONPath: .metadata.annotations.shipper\.booking\.com\/release\.clusters
+    description: The list of clusters where a release is supposed to be rolled out as per strategy.
+    name: Clusters
+    type: string
+    priority: -1
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/pkg/crds/application.go
+++ b/pkg/crds/application.go
@@ -40,5 +40,25 @@ var Application = &apiextensionv1beta1.CustomResourceDefinition{
 				},
 			},
 		},
+		AdditionalPrinterColumns: []apiextensionv1beta1.CustomResourceColumnDefinition{
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Latest Release",
+				Type:        "string",
+				Description: "The application's latest release.",
+				JSONPath:    ".status.history[-1]",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Rolling Out",
+				Type:        "string",
+				Description: "Whether the application is going through a rollout.",
+				JSONPath:    ".status.conditions[?(@.type=='RollingOut')].status",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Age",
+				Type:        "date",
+				Description: "The application's age.",
+				JSONPath:    ".metadata.creationTimestamp",
+			},
+		},
 	},
 }

--- a/pkg/crds/release.go
+++ b/pkg/crds/release.go
@@ -47,22 +47,29 @@ var Release = &apiextensionv1beta1.CustomResourceDefinition{
 		},
 		AdditionalPrinterColumns: []apiextensionv1beta1.CustomResourceColumnDefinition{
 			apiextensionv1beta1.CustomResourceColumnDefinition{
-				Name:        "Clusters",
-				Type:        "string",
-				Description: "The list of clusters where a release is supposed to be rolled out as per strategy.",
-				JSONPath:    ".metadata.annotations.shipper\\.booking\\.com\\/release\\.clusters",
-			},
-			apiextensionv1beta1.CustomResourceColumnDefinition{
 				Name:        "Step",
 				Type:        "string",
 				Description: "The current achieved step for a release as defined in the rollout strategy.",
 				JSONPath:    ".status.achievedStep.name",
 			},
 			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Errors",
+				Type:        "string",
+				Description: "Reasons from False conditions that show what's wrong with the release.",
+				JSONPath:    ".status.conditions[?(@.status=='False')].reason",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
 				Name:        "Age",
 				Type:        "date",
 				Description: "The release's age.",
 				JSONPath:    ".metadata.creationTimestamp",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Clusters",
+				Type:        "string",
+				Description: "The list of clusters where a release is supposed to be rolled out as per strategy.",
+				JSONPath:    ".metadata.annotations.shipper\\.booking\\.com\\/release\\.clusters",
+				Priority:    -1,
 			},
 		},
 	},


### PR DESCRIPTION
Closes #79.

Now, when using `kubectl`, one can expect the following outputs:

```
$ kubectl get app
NAME        LATEST RELEASE         ROLLING OUT   AGE
snowflake   snowflake-306ba2a4-0   False         22h

$ kubectl get rel
NAME                   STEP      ERRORS            AGE
snowflake-1578afe1-0   vanguard  BrokenChartSpec   10m

$ kubectl get rel -o wide
NAME                   STEP      ERRORS   AGE    CLUSTERS
snowflake-1779e269-0   full on            18m    local
```