### PR TITLE
Re-generated the TravisCI deployment key to fix "invalid credentials"…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,28 @@
 language: go
 go:
-- "1.12.x"
-
+- 1.12.x
 sudo: required
 dist: xenial
 services:
 - docker
-
 before_install:
 - sudo snap install microk8s --classic --channel=1.14/stable
 - sudo snap alias microk8s.kubectl kubectl
 - mkdir ~/.kube
 - microk8s.config > ~/.kube/config
-
-- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
-
+- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh |
+  sh -s -- -b $(go env GOPATH)/bin v1.17.1
 - microk8s.status --wait-ready
 - microk8s.enable registry
-
 install: true
-
 script:
 - "./ci/test.sh && ./ci/build.sh && ./ci/e2e.sh && ./ci/package.sh"
-
 after_success:
 - "./ci/build-release-files.sh"
 deploy:
   provider: releases
   api_key:
-    secure: pKwYDEsLMyFr1zwiKvxiS2qIn2dy+q/aCxzFHId0gIx/835yadoKarUtNOLJg6rNj536040MmLR9XSSfKMaZbRVPol6sER8pgglPOwKdmJ4T9asKnjKkkO4tkDJDmDWkTJJ/Gu8P0Hp0v7eyKvcyipvmTs9wXuPXdAR7S9oZANQhZ0yRkULgZc18LdsXuVVZW/J06JmIdtqdYLNq2WS/S8p7xwBBbLGKAjg2q6DsNgwetAY1Os+v+Wp4qJgmC2U+mmOrFJXQoSOtk1EkEHQNTdGRvATev4uG8Rl8f4rXa6W1Vt+n8p4KHbp7KkQXPODORzSJopAWqslFOXOdJMKhfyjsJtzoKQ7eO7dI3d1VEXrvniFjzeMjIxGDgSzKnK/dVUSs5i6ELpwVXAI/AvJz53Vo93C0BjWyzRppQcgidgWIR/8997hrQkOxichvKCScWTdO06W+m4xFuayRBN1sq5hVxCpZkrOCMJggrszqNQtg/M0eEoZW8NzLbbxzCYsDrwnf2xrPksbbb/c6Y1y6uT+tbyZWxiJPkN3fMKWWNyw/qkSdOXXybo1+70QY+GQiO2dxvbh6jRW2XizU9B3PGjd7MnnI7FuQtoNZotsPqgAiZw7QlFtaJ3zl95lBFLxqzaYHJcFY6bQiNB6pAjvldYHVQQqTwLU5w525qW9DTzY=
+    secure: sn8/ZmHs3IJIbmtUGTA3hvoynmTF1tZfoEaDJ1FY2abw9FutwU6XFHN4HUY2HGjBTXEd2jYYL7hlRoQsIUXILB7ausW7S73sVR5PtnRowzFkcYiCc0A2ZzhmsLWqrAY2761frqpRjhNVp/HEdKhszVTLuWA7hYWrojVyM0jlhpjZi98BYqy47ppVPOfZ8MdLRU9SS04EJpDvKLOnm1pHi1GO/8QiTVx4dStYpCZ9Y2wPQqK3Y3wVvRExFI/V0m51RzeTb/I63HU++6yWV28/llPfruFAEe6TA/th1xrUdh6fFwfnLHezIxmN5LNz6c0vdq3KKeKDeOWmSYnzwriq/LhFqCHVoqgbeOm6He7Yyz45vSV68nIHDbbPx/Q6caN1nPIE2/u7wrRlfJgzZIfLKNXjoUkCdxN1D0YmfXxyPotdh0qEdCyYDPPfuqZTO6Kj8cvRXaU3q6hFxVPaBjCdZitgLGFHOzibhZ2wxSQJtuPgqYsqZqjwmdvPaNGWoAwNVWEXmovQVLuCZryurEl9Ejf9GCFsgoMB+c5SiNto7QqUWed/iinUOoLlcKllYb+mUB28xTFVBS9svmmU5dBFGbaCSy7FiGxOhSxxOryfffkU98PCLYgRXC02PiilWP1fG9/oIQ0yL2um04To0gqpHTkfPaCsUfSfjAXtksChmFE=
   file_glob: true
   file:
     - "release-files/*.tgz"
@@ -36,4 +30,5 @@ deploy:
     - "release-files/kubernetes-deployment.yaml"
   skip_cleanup: true
   on:
+    repo: bookingcom/shipper
     tags: true


### PR DESCRIPTION
For projects registered on https://www.travis-ci.com, according to various comments on [this issue](https://github.com/travis-ci/travis-ci/issues/9610), the key should be generated by commands like `travis setup releases --pro`. The way I had done it before was without this switch, and I suspect that's why our pipeline is unable to deploy our release files.

This PR aims to solve this issue.