### PR TITLE
Chart repo index fetcher is moved to a background job

### DIFF
--- a/pkg/chart/repo/catalog.go
+++ b/pkg/chart/repo/catalog.go
@@ -72,7 +72,10 @@ func (c *Catalog) CreateRepoIfNotExist(repoURL string) (*Repo, error) {
 				fmt.Errorf("failed to create cache: %v", err),
 			)
 		}
-		repo = NewRepo(repoURL, cache, c.fetcher)
+		repo, err = NewRepo(repoURL, cache, c.fetcher)
+		if err != nil {
+			return nil, err
+		}
 		c.repos[name] = repo
 	}
 

--- a/pkg/chart/repo/catalog_test.go
+++ b/pkg/chart/repo/catalog_test.go
@@ -82,7 +82,9 @@ func TestCreateRepoIfNotExist(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			c := NewCatalog(testCase.factory, nil)
+			c := NewCatalog(testCase.factory, func(_ string) ([]byte, error) {
+				return []byte{}, nil
+			})
 			_, err := c.CreateRepoIfNotExist(testCase.url)
 			if (err == nil && testCase.err != nil) ||
 				(err != nil && testCase.err == nil) ||

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -2123,7 +2123,7 @@ func workingOnIncumbentCapacity(percent int, wg *sync.WaitGroup, t *testing.T) {
 func TestShouldNotProducePatches(t *testing.T) {
 	var wg sync.WaitGroup
 
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 25; i++ {
 		wg.Add(1)
 		go workingOnContenderCapacity(i, &wg, t)
 


### PR DESCRIPTION
Due to a massive overhead that happened as a consequence of a heavy
chart repo index request pattern (introduced in 0.5.0), application and
installation controller latencies spiked up.

This change is aiming to get rid of ad-hoc repo index fetch approach and
move this heavy operation to a background job.

From now on, every repo instance start polling chart repo index every 10
seconds. Once the data is successfully fetched, it is preserved as a
repo attribute unmarshalled. The first fetch is blocking: assuming
Shipper starts cold, there is no previous cache we can rely upon (it
starts in a new container). On top of it, index data is never cached on
the disk as there is no use for it any longer: in-memory only.

If repo fails to fetch repo index, it behaves quite naively: simply
spins next iteration with the same delay.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>