### PR TITLE
ci: sort out our release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
     secure: sn8/ZmHs3IJIbmtUGTA3hvoynmTF1tZfoEaDJ1FY2abw9FutwU6XFHN4HUY2HGjBTXEd2jYYL7hlRoQsIUXILB7ausW7S73sVR5PtnRowzFkcYiCc0A2ZzhmsLWqrAY2761frqpRjhNVp/HEdKhszVTLuWA7hYWrojVyM0jlhpjZi98BYqy47ppVPOfZ8MdLRU9SS04EJpDvKLOnm1pHi1GO/8QiTVx4dStYpCZ9Y2wPQqK3Y3wVvRExFI/V0m51RzeTb/I63HU++6yWV28/llPfruFAEe6TA/th1xrUdh6fFwfnLHezIxmN5LNz6c0vdq3KKeKDeOWmSYnzwriq/LhFqCHVoqgbeOm6He7Yyz45vSV68nIHDbbPx/Q6caN1nPIE2/u7wrRlfJgzZIfLKNXjoUkCdxN1D0YmfXxyPotdh0qEdCyYDPPfuqZTO6Kj8cvRXaU3q6hFxVPaBjCdZitgLGFHOzibhZ2wxSQJtuPgqYsqZqjwmdvPaNGWoAwNVWEXmovQVLuCZryurEl9Ejf9GCFsgoMB+c5SiNto7QqUWed/iinUOoLlcKllYb+mUB28xTFVBS9svmmU5dBFGbaCSy7FiGxOhSxxOryfffkU98PCLYgRXC02PiilWP1fG9/oIQ0yL2um04To0gqpHTkfPaCsUfSfjAXtksChmFE=
   file_glob: true
   file:
-    - "release-files/*.tgz"
+    - "release-files/*.tar.gz"
     - "release-files/sha256sums.txt"
     - "release-files/kubernetes-deployment.yaml"
   skip_cleanup: true

--- a/ci/build-release-files.sh
+++ b/ci/build-release-files.sh
@@ -31,18 +31,10 @@ function package {
     fi
 
     GO="go"
+
     build_and_package "$version" linux   amd64
-    build_and_package "$version" linux   386
     build_and_package "$version" darwin  amd64
-    build_and_package "$version" darwin  386
     build_and_package "$version" windows amd64
-    build_and_package "$version" windows 386
-    build_and_package "$version" freebsd amd64
-    build_and_package "$version" freebsd 386
-    build_and_package "$version" openbsd amd64
-    build_and_package "$version" openbsd 386
-    build_and_package "$version" netbsd  amd64
-    build_and_package "$version" netbsd  386
 }
 
 function create_deployment_yaml {
@@ -65,7 +57,7 @@ function build_and_package {
     mkdir -p "$BASE/${name}"
 
     export CGO_ENABLED=0
-    (export GOOS="$os" GOARCH="$arch"; $GO build -v -o "${BASE}/${name}/shipperctl" cmd/shipperctl/*.go)
+    (export GOOS="$os" GOARCH="$arch"; $GO build -o "${BASE}/${name}/shipperctl" cmd/shipperctl/*.go)
     echo "... done"
 
     echo "packing $name into $tgz ..."


### PR DESCRIPTION
First of all, let's not build for every platform under the sun, it takes
a ton of time for no particularly good reason.

Second of all, let's be a little bit less verbose, we don't need to know
precisely which packages were used to compile a binary, over and over
again.

Last but not least, point travis to the actual artifacts we built. If we
build *.tar.gz, let's not try to upload all those inexistent *.tgz files
;)