### PR TITLE
Chart repo errors are wrapped in Shipper errors fixes #152

### DIFF
--- a/pkg/chart/repo/repo.go
+++ b/pkg/chart/repo/repo.go
@@ -110,7 +110,7 @@ func (r *Repo) ResolveVersion(chartspec *shipper.Chart) (*repo.ChartVersion, err
 	}
 
 	if len(versions) == 0 {
-		return nil, repo.ErrNoChartVersion
+		return nil, shippererrors.NewChartVersionResolveError(chartspec, repo.ErrNoChartVersion)
 	}
 
 	var highestver *repo.ChartVersion
@@ -145,10 +145,10 @@ func (r *Repo) FetchChartVersions(chartspec *shipper.Chart) (repo.ChartVersions,
 
 	vs, ok := r.index.Load().(*repo.IndexFile).Entries[chartspec.Name]
 	if !ok {
-		return nil, repo.ErrNoChartName
+		return nil, shippererrors.NewChartVersionResolveError(chartspec, repo.ErrNoChartName)
 	}
 	if len(vs) == 0 {
-		return nil, repo.ErrNoChartVersion
+		return nil, shippererrors.NewChartVersionResolveError(chartspec, repo.ErrNoChartVersion)
 	}
 
 	var constraint *semver.Constraints
@@ -267,7 +267,7 @@ func (r *Repo) Fetch(chartspec *shipper.Chart) (*chart.Chart, error) {
 		}
 	}
 	if chartver == nil {
-		return nil, repo.ErrNoChartVersion
+		return nil, shippererrors.NewChartVersionResolveError(chartspec, repo.ErrNoChartVersion)
 	}
 
 	if chart, err := r.LoadCached(chartver); err == nil {

--- a/pkg/chart/repo/repo_test.go
+++ b/pkg/chart/repo/repo_test.go
@@ -1,7 +1,6 @@
 package repo
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -193,7 +192,7 @@ func TestResolveVersion(t *testing.T) {
 			"simple",
 			"=1.0.0",
 			"",
-			errors.New("no chart version found"),
+			fmt.Errorf("failed to resolve chart version [name: \"simple\", version: \"=1.0.0\", repo: \"https://charts.example.com\"]: no chart version found"),
 		},
 		{
 			"Existing dual version exact match",
@@ -327,7 +326,7 @@ func TestFetch(t *testing.T) {
 			"0.0.1",
 			"",
 			"",
-			fmt.Errorf("no chart name found"),
+			fmt.Errorf("failed to resolve chart version [name: \"unknown\", version: \"0.0.1\", repo: \"https://chart.example.com\"]: no chart name found"),
 		},
 		{
 			"Non-existing chart",
@@ -335,7 +334,7 @@ func TestFetch(t *testing.T) {
 			"10.20.30",
 			"nginx",
 			"",
-			fmt.Errorf("no chart version found"),
+			fmt.Errorf("failed to resolve chart version [name: \"nginx\", version: \"10.20.30\", repo: \"https://chart.example.com\"]: no chart version found"),
 		},
 		{
 			"Fails to fetch but exists in the cache",


### PR DESCRIPTION
This change is aiming to turn helm library errors into Shipper errors so
the responsible caller gets an idea if the error should be retried.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>