### PR TITLE
ReleaseController application picks the tip of the release chain as contender

### DIFF
--- a/pkg/chart/repo/catalog.go
+++ b/pkg/chart/repo/catalog.go
@@ -23,7 +23,7 @@ func DefaultRemoteFetcher(url string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unsuccessful response code: %s (%d)", resp.Status, resp.StatusCode)
+		return nil, fmt.Errorf("bad response code: %s (%d)", resp.Status, resp.StatusCode)
 	}
 
 	return ioutil.ReadAll(resp.Body)

--- a/pkg/chart/repo/repo_test.go
+++ b/pkg/chart/repo/repo_test.go
@@ -345,7 +345,7 @@ func TestFetch(t *testing.T) {
 			"0.0.2",
 			"",
 			"",
-			fmt.Errorf("failed to read file \"non-existing-0.0.2.tgz\": open testdata/non-existing-0.0.2.tgz: no such file or directory"),
+			fmt.Errorf("failed to fetch chart [name: \"non-existing\", version: \"0.0.2\", repo: \"https://charts.example.com/non-existing-0.0.2.tgz\"]: failed to read file \"non-existing-0.0.2.tgz\": open testdata/non-existing-0.0.2.tgz: no such file or directory"),
 		},
 	}
 

--- a/pkg/util/application/releases.go
+++ b/pkg/util/application/releases.go
@@ -1,9 +1,9 @@
 package application
 
 import (
-	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	"github.com/bookingcom/shipper/pkg/errors"
+	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 )
 
 // GetContender returns the contender from the given Release slice. The slice
@@ -21,7 +21,15 @@ func GetContender(appName string, rels []*shipper.Release) (*shipper.Release, er
 // An incumbent release is the first release in this slice that is considered
 // completed.
 func GetIncumbent(appName string, rels []*shipper.Release) (*shipper.Release, error) {
+	contender, err := GetContender(appName, rels)
+	if err != nil {
+		return nil, err
+	}
 	for _, r := range rels {
+		// As per https://github.com/bookingcom/shipper/pull/166#discussion_r319758380
+		if r.GetName() == contender.GetName() {
+			continue
+		}
 		if releaseutil.ReleaseComplete(r) {
 			return r, nil
 		}


### PR DESCRIPTION
The current implementation has a slightly relaxed algorithm of finding
contender and incumbent in the chain of releases: in particular, the
latest (sorted by generation) scheduled release is identified as a
contender and the latest complete one is our incumbent.

This commit changes the approach and forces release controller to start
using releaseutil methods for finding incumbent and contender. The
incumbent finding is still very naive as it's relying on release status
to figure out whether it's complete or not. On the improvement side, we
got rid of using the most dangerous condition in release object:
scheduled criteria. From now on, we always pick the tip of the release
chain.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>