### PR TITLE
docs: value of enable-helm-release-workaround requires quotes

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -45,7 +45,7 @@ able to balance traffic between multiple *Releases*.
 
 If you cannot modify the Chart you're rolling out, you can ask Shipper to
 remove the ``release`` selector from the *Service* ``selector`` by adding the
-``enable-helm-release-workaround: true`` label to your *Application*. This
+``enable-helm-release-workaround: "true"`` label to your *Application*. This
 workaround helps make Charts created with ``helm create`` work out of the box.
 
 **************


### PR DESCRIPTION
This has wasted one hour of life of at least one person: all labels must
be strings, but the YAML parser serializes `true` (no quotes) as a
boolean. This makes the apiserver barf with gibberish deserialization
errors when trying to apply the object.