### PR TITLE
Updated Application spec in docs with chart ranges

### DIFF
--- a/docs/api-reference/porcelain/application.rst
+++ b/docs/api-reference/porcelain/application.rst
@@ -23,7 +23,7 @@ defining the range of acceptable chart versions. Shipper will resolve an
 appropriate available chart version and pin the *Release* on it. Shipper
 resolves the version in-place: it will substitute the initial constraint with a
 specific resolved version and preserve the initial constraint in the Application
-annotation.
+annotation named ``shipper.booking.com/app.chart.version.raw``.
 
 The resolved ``.spec.template`` field will be copied to a new *Release*
 object under the ``.spec.environment`` field during deployment.

--- a/docs/examples/application-minimal.yaml
+++ b/docs/examples/application-minimal.yaml
@@ -7,7 +7,7 @@ spec:
     # helm chart for this application
     chart:
       name: reviews-api
-      version: 0.0.1
+      version: "0.0.1"
       repoUrl: https://charts.example.com
     # how to select clusters to deploy to
     clusterRequirements:

--- a/docs/examples/application.yaml
+++ b/docs/examples/application.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     chart:
       name: reviews-api
-      version: 0.0.1
+      version: "~0.1"
       repoUrl: https://charts.example.com
     clusterRequirements:
       capabilities:


### PR DESCRIPTION
This commit updates the documentation and promotes the new feature of 0.5: helm chart ranges.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>