### PR TITLE
Remove unused ReleaseConditionTypeInstalled

### DIFF
--- a/pkg/apis/shipper/v1alpha1/types.go
+++ b/pkg/apis/shipper/v1alpha1/types.go
@@ -220,7 +220,6 @@ type ReleaseConditionType string
 
 const (
 	ReleaseConditionTypeScheduled ReleaseConditionType = "Scheduled"
-	ReleaseConditionTypeInstalled ReleaseConditionType = "Installed"
 	ReleaseConditionTypeComplete  ReleaseConditionType = "Complete"
 )
 

--- a/pkg/controller/application/application_controller_test.go
+++ b/pkg/controller/application/application_controller_test.go
@@ -432,7 +432,6 @@ func TestStatusStableState(t *testing.T) {
 	}
 
 	releaseA.Status.Conditions = []shipper.ReleaseCondition{
-		{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 		{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
 	}
 
@@ -453,7 +452,6 @@ func TestStatusStableState(t *testing.T) {
 	}
 
 	releaseB.Status.Conditions = []shipper.ReleaseCondition{
-		{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 		{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
 	}
 
@@ -976,7 +974,6 @@ func TestStateRollingOut(t *testing.T) {
 	incumbent := newRelease(incumbentName, app)
 	incumbent.Annotations[shipper.ReleaseGenerationAnnotation] = "0"
 	incumbent.Status.Conditions = []shipper.ReleaseCondition{
-		{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 		{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
 	}
 	f.objects = append(f.objects, incumbent)

--- a/pkg/controller/release/executor_test.go
+++ b/pkg/controller/release/executor_test.go
@@ -10,7 +10,6 @@ import (
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	"github.com/bookingcom/shipper/pkg/conditions"
-	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
@@ -210,7 +209,6 @@ func buildIncumbent(totalReplicaCount uint) *releaseInfo {
 				Name: "full on",
 			},
 			Conditions: []shipper.ReleaseCondition{
-				{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 				{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
 			},
 		},
@@ -603,10 +601,6 @@ func ensureFinalReleasePatches(e *Executor) error {
 					return fmt.Errorf("expected a ReleaseUpdateResult, got something else")
 				} else {
 					if p.Name == contenderName {
-						installedCond := releaseutil.GetReleaseCondition(*p.NewStatus, shipper.ReleaseConditionTypeInstalled)
-						if installedCond != nil && installedCond.Status == corev1.ConditionTrue {
-							return fmt.Errorf("expected contender to be installed")
-						}
 						if p.NewStatus.AchievedStep == nil || p.NewStatus.AchievedStep.Step != 2 {
 							return fmt.Errorf(
 								"expected contender achievedSteps %d, got %v",

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -352,7 +352,6 @@ func (f *fixture) buildIncumbent(namespace string, relName string, replicaCount 
 				Name: "full on",
 			},
 			Conditions: []shipper.ReleaseCondition{
-				{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 				{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
 				{Type: shipper.ReleaseConditionTypeScheduled, Status: corev1.ConditionTrue},
 			},
@@ -1156,7 +1155,6 @@ func (f *fixture) expectReleaseReleased(rel *shipper.Release, targetStep int32) 
 			},
 			Conditions: []shipper.ReleaseCondition{
 				{Type: shipper.ReleaseConditionTypeComplete, Status: corev1.ConditionTrue},
-				{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue},
 				{Type: shipper.ReleaseConditionTypeScheduled, Status: corev1.ConditionTrue},
 			},
 			Strategy: &shipper.ReleaseStrategyStatus{
@@ -2396,7 +2394,6 @@ func TestContenderReleaseIsInstalled(t *testing.T) {
 		contender.capacityTarget.Status.Clusters[0].AvailableReplicas = totalReplicaCount
 		contender.trafficTarget.Spec.Clusters[0].Weight = 100
 		contender.trafficTarget.Status.Clusters[0].AchievedTraffic = 100
-		releaseutil.SetReleaseCondition(&contender.release.Status, shipper.ReleaseCondition{Type: shipper.ReleaseConditionTypeInstalled, Status: corev1.ConditionTrue, Reason: "", Message: ""})
 
 		incumbent.trafficTarget.Spec.Clusters[0].Weight = 0
 		incumbent.trafficTarget.Status.Clusters[0].AchievedTraffic = 0

--- a/pkg/util/release/conditions.go
+++ b/pkg/util/release/conditions.go
@@ -54,11 +54,6 @@ func RemoveReleaseCondition(status shipper.ReleaseStatus, condType shipper.Relea
 	status.Conditions = filterOutCondition(status.Conditions, condType)
 }
 
-func ReleaseInstalled(release *shipper.Release) bool {
-	installedCond := GetReleaseCondition(release.Status, shipper.ReleaseConditionTypeInstalled)
-	return installedCond != nil && installedCond.Status == corev1.ConditionTrue
-}
-
 func ReleaseScheduled(release *shipper.Release) bool {
 	scheduledCond := GetReleaseCondition(release.Status, shipper.ReleaseConditionTypeScheduled)
 	return scheduledCond != nil && scheduledCond.Status == corev1.ConditionTrue


### PR DESCRIPTION
This has been unused for a while (from before the release controller
refactoring, as far as I could see), and its existence confused me once
or twice. To avoid future confusion, let's get rid of it.