### PR TITLE
update rollout block docs

### DIFF
--- a/docs/user/rolling-out.rst
+++ b/docs/user/rolling-out.rst
@@ -338,6 +338,7 @@ This will show all information about all rollout blocks in the namsespace (defau
 
 This might look like this:
 
-.. code-block::
+.. code-block:: text
+
     NAMESPACE               NAME        MESSAGE                                   AUTHOR TYPE   AUTHOR NAME   OVERRIDING APPLICATIONS   OVERRIDING RELEASES
     rollout-blocks-global   dns-outage  DNS issues, troubleshooting in progress   user          jdoe          default/super-server      default/super-server-83e4eedd-0


### PR DESCRIPTION
Without a type, the code-block simply does not show. In this commit I added a type to the last code-block in order for the example of the output for ` $ kubectl -n rollout-blocks-global get rb -o wide` to show.