### PR TITLE
Release controller exposes executor problems fixes #174

### DIFF
--- a/pkg/conditions/constants.go
+++ b/pkg/conditions/constants.go
@@ -25,6 +25,7 @@ const (
 	FetchReleaseFailed                  = "FetchReleaseFailed"
 	BrokenReleaseGeneration             = "BrokenReleaseGeneration"
 	BrokenApplicationObservedGeneration = "BrokenApplicationObservedGeneration"
+	StrategyExecutionFailed             = "StrategyExecutionFailed"
 
 	ChartError  = "ChartError"
 	ClientError = "ClientError"

--- a/pkg/controller/release/application.go
+++ b/pkg/controller/release/application.go
@@ -12,8 +12,10 @@ import (
 	"k8s.io/klog"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	"github.com/bookingcom/shipper/pkg/conditions"
 	shippercontroller "github.com/bookingcom/shipper/pkg/controller"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
+	apputil "github.com/bookingcom/shipper/pkg/util/application"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 )
 
@@ -101,6 +103,18 @@ func (c *Controller) syncOneApplicationHandler(key string) error {
 	klog.V(4).Infof("Executing the strategy on Application %q", key)
 	patches, transitions, err := strategyExecutor.Execute()
 	if err != nil {
+		releaseSyncedCond := apputil.NewApplicationCondition(
+			shipper.ApplicationConditionTypeReleaseSynced,
+			corev1.ConditionFalse,
+			conditions.StrategyExecutionFailed,
+			fmt.Sprintf("failed to execute application strategy: %q", err),
+		)
+		apputil.SetApplicationCondition(&app.Status, *releaseSyncedCond)
+		_, err = c.clientset.ShipperV1alpha1().Applications(app.Namespace).Update(app)
+		if err != nil {
+			return shippererrors.NewKubeclientUpdateError(app, err).
+				WithShipperKind("Application")
+		}
 		return err
 	}
 


### PR DESCRIPTION
Release controller is a 2-step process: processing a release initiates a
new processing loop for the parental application. In the current
implementation the process never broughts strategy execution issues on
the surface, therefore a user has no way to troubleshoot their
application.

This change enforces controller to preserve failure condition in the
application object. In this case the condition will be
ApplicationConditionTypeReleaseSynced set to False with a reason
StrategyExecutionFailed.

The parental application was chosen to be the medium for this condition
(in contrast to choosing the relevant release object) because at this
stage the controller is handling the application object itself and
strategy executor is working on a duplet of releases. Under these
circumstances choosing the contender might be another alternative as
user is expected to check it first. On the other hand, contextually this
might be an irrelevant location: strategy problems are encorporated in
application spec template. Therefore application was identified as the
optimal condition holder.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>