### PR TITLE
crds: additional printer columns for Application

### DIFF
--- a/crd/Application-crd.yaml
+++ b/crd/Application-crd.yaml
@@ -4,6 +4,19 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: applications.shipper.booking.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.history[-1]
+    description: The application's latest release.
+    name: Latest release
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="RollingOut")].status
+    description: Whether the application is going through a rollout.
+    name: Rolling Out
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The applications's age.
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/pkg/crds/application.go
+++ b/pkg/crds/application.go
@@ -40,5 +40,25 @@ var Application = &apiextensionv1beta1.CustomResourceDefinition{
 				},
 			},
 		},
+		AdditionalPrinterColumns: []apiextensionv1beta1.CustomResourceColumnDefinition{
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Latest Release",
+				Type:        "string",
+				Description: "The application's latest release.",
+				JSONPath:    ".status.history[-1]",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Rolling Out",
+				Type:        "string",
+				Description: "Whether the application is going through a rollout.",
+				JSONPath:    ".status.conditions[?(@.type=='RollingOut')].status",
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Age",
+				Type:        "date",
+				Description: "The application's age.",
+				JSONPath:    ".metadata.creationTimestamp",
+			},
+		},
 	},
 }


### PR DESCRIPTION
Now, when doing `kubectl get app`, output will look like the following:

```
NAME        LATEST RELEASE         ROLLING OUT   AGE
snowflake   snowflake-306ba2a4-0   False         22h
```