### PR TITLE
Shipper in 5 minutes doc: curl latest shipper.deployment.yaml fixes #130

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -95,7 +95,7 @@ service accounts, and so on, let's create the Shipper *Deployment*:
 
 .. code-block:: shell
 
-    $ kubectl create -f https://github.com/bookingcom/shipper/releases/download/v0.1.0/shipper-deploy.yaml
+    $ kubectl create -f https://github.com/bookingcom/shipper/releases/latest/download/shipper.deployment.yaml
     deployment.apps/shipper created
 
 This will create an instance of Shipper in the ``shipper-system`` namespace.


### PR DESCRIPTION
In the section ["deploy with Shipper"](https://docs.shipper-k8s.io/en/latest/start/install.html#step-4-deploy-shipper) the download link leads to an old release. This commit changes this link to latest release.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>