### PR TITLE
shipper-state-metrics: initialize rolloutblocks lister

### DIFF
--- a/cmd/shipper-state-metrics/main.go
+++ b/cmd/shipper-state-metrics/main.go
@@ -68,6 +68,7 @@ func main() {
 		ctsLister:      shipperInformerFactory.Shipper().V1alpha1().CapacityTargets().Lister(),
 		ttsLister:      shipperInformerFactory.Shipper().V1alpha1().TrafficTargets().Lister(),
 		clustersLister: shipperInformerFactory.Shipper().V1alpha1().Clusters().Lister(),
+		rbLister:       shipperInformerFactory.Shipper().V1alpha1().RolloutBlocks().Lister(),
 
 		nssLister:     kubeInformerFactory.Core().V1().Namespaces().Lister(),
 		secretsLister: kubeInformerFactory.Core().V1().Secrets().Lister(),


### PR DESCRIPTION
This fixes a panic when running the collector:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x116ce51]

goroutine 342 [running]:
main.ShipperStateMetrics.collectRolloutBlocks(0x1610760, 0xc00041e010, 0x1610860, 0xc00041e030, 0x1610820, 0xc00041e050, 0x16107a0, 0xc00041e070, 0x16108e0, 0xc00041e090, ...)
	/shipper/cmd/shipper-state-metrics/collector.go:351 +0x101
main.ShipperStateMetrics.Collect(0x1610760, 0xc00041e010, 0x1610860, 0xc00041e030, 0x1610820, 0xc00041e050, 0x16107a0, 0xc00041e070, 0x16108e0, 0xc00041e090, ...)
	/shipper/cmd/shipper-state-metrics/collector.go:101 +0x194
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/shipper/vendor/github.com/prometheus/client_golang/prometheus/registry.go:434 +0x19d
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/shipper/vendor/github.com/prometheus/client_golang/prometheus/registry.go:445 +0x571
```