### PR TITLE
installation controller: also migrate CanOverride

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -216,15 +216,11 @@ func (c *Controller) enqueueInstallationTarget(obj interface{}) {
 // processInstallation attempts to install the related InstallationTarget on
 // all target clusters.
 func (c *Controller) processInstallation(it *shipper.InstallationTarget) error {
-	if !it.Spec.CanOverride {
-		klog.V(3).Infof("InstallationTarget %q is not allowed to override, skipping", it.Name)
-		return nil
-	}
-
 	// If an InstallationTarget was created before we introduced
-	// self-contained InstallationTargets, it will not contain a chart nor
-	// values, so it will need to be migrated. We do so by getting those
-	// values from the release.
+	// self-contained InstallationTargets, it will not contain a chart,
+	// values, nor a reliable CanOverride, so it will need to be migrated.
+	// We do so by looking at the associated release, and the current
+	// contender.
 	// Note that this is temporary. After this code gets released, it can
 	// safely be dropped in the next version.
 	if it.Spec.Chart == nil {
@@ -233,7 +229,22 @@ func (c *Controller) processInstallation(it *shipper.InstallationTarget) error {
 		release, err := relNamespaceLister.ReleaseForInstallationTarget(it)
 		if err != nil {
 			return shippererrors.NewUnrecoverableError(fmt.Errorf(
-				"InstallationTarget is missing Chart, and the owning release cannot be found: %s", err))
+				"InstallationTarget %q is missing Chart, and the owning release cannot be found: %s", shippercontroller.MetaKey(it), err))
+		}
+
+		appName, ok := release.GetLabels()[shipper.AppLabel]
+		if !ok {
+			return shippererrors.NewUnrecoverableError(fmt.Errorf(
+				"Release for InstallationTarget %q is missing label %q", shippercontroller.MetaKey(it), shipper.AppLabel))
+		}
+
+		contenderRel, err := relNamespaceLister.ContenderForApplication(appName)
+		if err != nil {
+			return err
+		}
+
+		if contenderRel.Name == release.Name {
+			it.Spec.CanOverride = true
 		}
 
 		it.Spec.Chart = release.Spec.Environment.Chart.DeepCopy()
@@ -242,6 +253,20 @@ func (c *Controller) processInstallation(it *shipper.InstallationTarget) error {
 			values := release.Spec.Environment.Values.DeepCopy()
 			it.Spec.Values = &values
 		}
+
+		_, err = c.shipperclientset.ShipperV1alpha1().InstallationTargets(it.Namespace).Update(it)
+		if err != nil {
+			return shippererrors.NewKubeclientUpdateError(it, err).
+				WithShipperKind("InstallationTarget")
+		}
+
+		return nil
+
+	}
+
+	if !it.Spec.CanOverride {
+		klog.V(3).Infof("InstallationTarget %q is not allowed to override, skipping", shippercontroller.MetaKey(it))
+		return nil
 	}
 
 	// Build .status over based on the current .spec.clusters.

--- a/pkg/controller/installation/utils_test.go
+++ b/pkg/controller/installation/utils_test.go
@@ -207,6 +207,13 @@ func buildRelease(namespace, name string, chart shipper.Chart) *shipper.Release 
 			Name:      name,
 			Namespace: namespace,
 			UID:       types.UID("foobar"),
+			Labels: map[string]string{
+				shipper.AppLabel:     name,
+				shipper.ReleaseLabel: name,
+			},
+			Annotations: map[string]string{
+				shipper.ReleaseGenerationAnnotation: "0",
+			},
 		},
 		Spec: shipper.ReleaseSpec{
 			Environment: shipper.ReleaseEnvironment{


### PR DESCRIPTION
This was an oversight on my part in #114: by default, CanOverride will
always be false, but that's not always what's supposed to happen: if
we're migrating an InstallationTarget that belongs to a contender
release, CanOverride needs to be set to true.

This reintroduces some code that was removed in #114, but it can be
safely removed in the next version of shipper, as all objects would've
been migrated.