### PR TITLE
Revert Application.additionalPrinterColumns from -1 to @length-1

### DIFF
--- a/crd/Application-crd.yaml
+++ b/crd/Application-crd.yaml
@@ -5,7 +5,7 @@ metadata:
   name: applications.shipper.booking.com
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.history[(@.length-1)]
+  - JSONPath: .status.history[-1]
     description: The application's latest release.
     name: Latest release
     type: string

--- a/pkg/crds/application.go
+++ b/pkg/crds/application.go
@@ -45,7 +45,7 @@ var Application = &apiextensionv1beta1.CustomResourceDefinition{
 				Name:        "Latest Release",
 				Type:        "string",
 				Description: "The application's latest release.",
-				JSONPath:    ".status.history[(@.length-1)]",
+				JSONPath:    ".status.history[-1]",
 			},
 			apiextensionv1beta1.CustomResourceColumnDefinition{
 				Name:        "Rolling Out",


### PR DESCRIPTION
This reverts commit 2d57473a373651eed8eae13369fff9b3b6e60d62.
client-go’s jsonpath doesn’t support @.properties and negative indexes
are fully supported. We tried this after we discovered that
a941d3a0ae8f504bd62eacd1eba985b4edc94c6d actually makes `kubectl get
app` cause a panic in the apiserver for k8s 1.13.

So we're going back to `[-1]` index, and we're aware that we'll not be
compatible with k8s 1.13 by default. If you need such compatibility, you
can remove additionalPrinterColumns from the Application crd manually
after running `shipperctl`.  Shipper will continue to work perfectly
fine without it ^_^