### PR TITLE
installation controller: remove migration scaffolding

### DIFF
--- a/CHANGELOG-0.7.md
+++ b/CHANGELOG-0.7.md
@@ -1,0 +1,11 @@
+## Changelog since v0.6.0
+
+### Breaking Changes
+
+* Due to changes in the InstallationTarget CRD
+  ([#183](https://github.com/bookingcom/shipper/pull/183)), Shipper v0.6.0 had
+  a small piece of code that would perform a data migration automatically the
+  first time it ran. In Shipper v0.7.0, that code has been removed, so the
+  migration will no longer happen. If you're upgrading Shipper from an earlier
+  version, we recommend that you first upgrade to v0.6.0, so your
+  InstallationTargets can be migrated properly.

--- a/pkg/controller/installation/installer.go
+++ b/pkg/controller/installation/installer.go
@@ -497,16 +497,7 @@ func (i *Installer) installManifests(
 		labels := existingObj.GetLabels()
 		owner, ok := labels[shipper.InstallationTargetOwnerLabel]
 		if !ok {
-			// If an object was created before we introduced
-			// self-contained InstallationTargets, it will not
-			// contain InstallationTargetOwnerLabel, values, so it
-			// will need to be migrated. We do so by getting the
-			// older ReleaseLabel.
-			if relLabel, ok := labels[shipper.ReleaseLabel]; ok {
-				owner = relLabel
-			} else {
-				return shippererrors.NewMissingInstallationTargetOwnerLabelError(existingObj)
-			}
+			return shippererrors.NewMissingInstallationTargetOwnerLabelError(existingObj)
 		}
 
 		// If the existing object is owned by the installation target,

--- a/pkg/controller/installation/utils_test.go
+++ b/pkg/controller/installation/utils_test.go
@@ -11,7 +11,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -198,27 +197,5 @@ func buildChart(appName, version, repoUrl string) shipper.Chart {
 		Name:    appName,
 		Version: version,
 		RepoURL: repoUrl,
-	}
-}
-
-func buildRelease(namespace, name string, chart shipper.Chart) *shipper.Release {
-	return &shipper.Release{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       types.UID("foobar"),
-			Labels: map[string]string{
-				shipper.AppLabel:     name,
-				shipper.ReleaseLabel: name,
-			},
-			Annotations: map[string]string{
-				shipper.ReleaseGenerationAnnotation: "0",
-			},
-		},
-		Spec: shipper.ReleaseSpec{
-			Environment: shipper.ReleaseEnvironment{
-				Chart: chart,
-			},
-		},
 	}
 }


### PR DESCRIPTION
In #183, we made changes to the InstallationTarget CRD that required a
small data migration. As promised, now that v0.6.0 is out, we can
clean that up as it's no longer needed. We also dutifully notify our
users that they should upgrade to v0.6.0 first in our changelog.