### PR TITLE
kubernetes: improve shipper's deployments

### DIFF
--- a/Dockerfile.shipper
+++ b/Dockerfile.shipper
@@ -2,4 +2,4 @@ FROM alpine:3.8
 LABEL authors="Parham Doustdar <parham.doustdar@booking.com>, Alexey Surikov <alexey.surikov@booking.com>, Igor Sutton <igor.sutton@booking.com>, Ben Tyler <benjamin.tyler@booking.com>"
 RUN apk add ca-certificates
 ADD build/shipper.linux-amd64 /bin/shipper
-ENTRYPOINT ["shipper", "-v", "4", "-logtostderr"]
+ENTRYPOINT ["shipper"]

--- a/Dockerfile.shipper-state-metrics
+++ b/Dockerfile.shipper-state-metrics
@@ -2,4 +2,4 @@ FROM alpine:3.8
 LABEL authors="Parham Doustdar <parham.doustdar@booking.com>, Alexey Surikov <alexey.surikov@booking.com>, Igor Sutton <igor.sutton@booking.com>, Ben Tyler <benjamin.tyler@booking.com>"
 RUN apk add ca-certificates
 ADD build/shipper-state-metrics.linux-amd64 /bin/shipper-state-metrics
-ENTRYPOINT ["shipper-state-metrics", "-v", "2"]
+ENTRYPOINT ["shipper-state-metrics"]

--- a/kubernetes/shipper-state-metrics.deployment.yaml
+++ b/kubernetes/shipper-state-metrics.deployment.yaml
@@ -9,6 +9,11 @@ spec:
   selector:
     matchLabels:
       app: shipper-state-metrics
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -18,6 +23,14 @@ spec:
       - name: shipper-state-metrics
         image: <IMAGE>
         imagePullPolicy: Always
+        args:
+          - "-v"
+          - "2"
         ports:
-        - containerPort: 8890
+        - name: metrics
+          containerPort: 8890
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 8890
       serviceAccountName: shipper-management-cluster

--- a/kubernetes/shipper.deployment.yaml
+++ b/kubernetes/shipper.deployment.yaml
@@ -9,10 +9,17 @@ spec:
   selector:
     matchLabels:
       app: shipper
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: shipper
+      annotations:
+        prometheus.io/scrape_port: '8889'
     spec:
       containers:
       - name: shipper
@@ -27,8 +34,14 @@ spec:
           - "9443"
           - "-resync"
           - "10m"
+          - "-v"
+          - "4"
+          - "-logtostderr"
         ports:
-        - containerPort: 9443
+        - name: metrics
+          containerPort: 8889
+        - name: webhook
+          containerPort: 9443
         volumeMounts:
         - mountPath: /etc/webhook/certs
           name: webhook-certs


### PR DESCRIPTION
This brings the Shipper you deploy out of the box closer to the way we
deploy it in Booking.

This also fixes a tiny bug where the metrics port was not exposed in the
`shipper` deployment.