### PR TITLE
shipper: disable resync for native k8s objects

### DIFF
--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -132,7 +132,7 @@ func main() {
 	stopCh := setupSignalHandler()
 	metricsReadyCh := make(chan struct{})
 
-	kubeInformerFactory := informers.NewSharedInformerFactory(informerKubeClient, *resync)
+	kubeInformerFactory := informers.NewSharedInformerFactory(informerKubeClient, 0*time.Second)
 	shipperInformerFactory := shipperinformers.NewSharedInformerFactory(informerShipperClient, *resync)
 
 	shipperscheme.AddToScheme(scheme.Scheme)
@@ -161,7 +161,6 @@ func main() {
 		shipperInformerFactory.Shipper().V1alpha1().Clusters(),
 		*ns,
 		restTimeout,
-		resync,
 	)
 
 	wg.Add(1)

--- a/pkg/clusterclientstore/store.go
+++ b/pkg/clusterclientstore/store.go
@@ -33,7 +33,6 @@ type Store struct {
 	ns          string
 	buildClient ClientBuilderFunc
 	restTimeout *time.Duration
-	resync      *time.Duration
 	cache       cache.CacheServer
 
 	secretInformer  corev1informer.SecretInformer
@@ -59,14 +58,12 @@ func NewStore(
 	secretInformer corev1informer.SecretInformer,
 	clusterInformer shipperinformer.ClusterInformer,
 	ns string,
-	restTimeout,
-	resync *time.Duration,
+	restTimeout *time.Duration,
 ) *Store {
 	s := &Store{
 		ns:          ns,
 		buildClient: buildClient,
 		restTimeout: restTimeout,
-		resync:      resync,
 		cache:       cache.NewServer(),
 
 		secretInformer:  secretInformer,
@@ -284,12 +281,7 @@ func (s *Store) create(cluster *shipper.Cluster, secret *corev1.Secret) error {
 		return shippererrors.NewClusterClientBuild(cluster.Name, err)
 	}
 
-	var resyncPeriod time.Duration
-	if s.resync != nil {
-		resyncPeriod = *s.resync
-	}
-
-	informerFactory := kubeinformers.NewSharedInformerFactory(informerClient, resyncPeriod)
+	informerFactory := kubeinformers.NewSharedInformerFactory(informerClient, 0*time.Second)
 	// Register all the resources that the controllers are interested in, e.g.
 	// informerFactory.Core().V1().Pods().Informer().
 	for _, cb := range s.subscriptionRegisterFuncs {

--- a/pkg/clusterclientstore/store_test.go
+++ b/pkg/clusterclientstore/store_test.go
@@ -284,7 +284,6 @@ func (f *fixture) newStore() (*Store, kubeinformers.SharedInformerFactory, shipp
 		shipperInformerFactory.Shipper().V1alpha1().Clusters(),
 		shipper.ShipperNamespace,
 		f.restTimeout,
-		&noResyncPeriod,
 	)
 
 	return store, kubeInformerFactory, shipperInformerFactory

--- a/pkg/testing/clusterclientstore.go
+++ b/pkg/testing/clusterclientstore.go
@@ -49,7 +49,6 @@ func ClusterClientStore(
 		shipperInformerFactory.Shipper().V1alpha1().Clusters(),
 		TestNamespace,
 		nil,
-		nil,
 	)
 
 	kubeInformerFactory.Start(stopCh)


### PR DESCRIPTION
This is a fun little optimization that turns out to be much safer than
it sounds :)

Some controllers, such as Capacity and Traffic controllers, subscribe to
events in both the object they own (a CapacityTarget or TrafficTarget)
as well as native kubernetes objects they're interested in (such as a
Deployment or a Pod), so they can update the object they own accordingly
whenever the state of the world changes.

This is all fine and good until resyncs enter the picture. If both the
CRDs and the native objects get resynced at the same time (which they
more or less do) and are processed by different workqueues (which they
are), they'll race in a way that an update in one may trigger a new item
in the workqueue for the other one, *that just got processed*, just
because we can't take advantage of deduplication across different
workqueues.

Disabling resyncs from native k8s objects in this case is safe because
the CRDs will still keep resyncs (for now), and they're responsible for
looking at all the objects they're interested in anyway, so we get
better performance for no risk ^_^

As a bonus, the clusterclientstore completely loses its resync option,
simplifying initialization a little bit.