### PR TITLE
traffic controller: watch Pod events

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -244,7 +244,14 @@ func (c *Controller) enqueueInstallationTargetFromObject(obj interface{}) {
 	// Also not using ObjectReference here because it would go over cluster
 	// boundaries. While technically it's probably ok, I feel like it'd be
 	// abusing the feature.
-	rel := kubeobj.GetLabels()[shipper.ReleaseLabel]
+	rel, ok := kubeobj.GetLabels()[shipper.ReleaseLabel]
+	if !ok {
+		runtime.HandleError(fmt.Errorf(
+			"object %q does not have label %s. FilterFunc not working?",
+			shippercontroller.MetaKey(kubeobj), shipper.ReleaseLabel))
+		return
+	}
+
 	it, err := c.getInstallationTargetForReleaseAndNamespace(rel, kubeobj.GetNamespace())
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("cannot get installation target for release '%s/%s': %#v", rel, kubeobj.GetNamespace(), err))

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -245,13 +245,13 @@ func (c *Controller) enqueueInstallationTargetFromObject(obj interface{}) {
 	// boundaries. While technically it's probably ok, I feel like it'd be
 	// abusing the feature.
 	rel := kubeobj.GetLabels()[shipper.ReleaseLabel]
-	tt, err := c.getInstallationTargetForReleaseAndNamespace(rel, kubeobj.GetNamespace())
+	it, err := c.getInstallationTargetForReleaseAndNamespace(rel, kubeobj.GetNamespace())
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("cannot get installation target for release '%s/%s': %#v", rel, kubeobj.GetNamespace(), err))
 		return
 	}
 
-	c.enqueueInstallationTarget(tt)
+	c.enqueueInstallationTarget(it)
 }
 
 func (c *Controller) getInstallationTargetForReleaseAndNamespace(release, namespace string) (*shipper.InstallationTarget, error) {

--- a/pkg/controller/traffic/traffic_controller.go
+++ b/pkg/controller/traffic/traffic_controller.go
@@ -405,7 +405,14 @@ func (c *Controller) enqueueTrafficTargetFromPod(obj interface{}) {
 	// Also not using ObjectReference here because it would go over cluster
 	// boundaries. While technically it's probably ok, I feel like it'd be
 	// abusing the feature.
-	rel := pod.GetLabels()[shipper.ReleaseLabel]
+	rel, ok := pod.GetLabels()[shipper.ReleaseLabel]
+	if !ok {
+		runtime.HandleError(fmt.Errorf(
+			"object %q does not have label %s. FilterFunc not working?",
+			shippercontroller.MetaKey(pod), shipper.ReleaseLabel))
+		return
+	}
+
 	tt, err := c.getTrafficTargetForReleaseAndNamespace(rel, pod.GetNamespace())
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("cannot get traffic target for release '%s/%s': %#v", rel, pod.GetNamespace(), err))

--- a/pkg/controller/traffic/traffic_controller_test.go
+++ b/pkg/controller/traffic/traffic_controller_test.go
@@ -186,6 +186,9 @@ func (f *fixture) run() {
 		},
 	}
 
+	informer.Start(stopCh)
+	informer.WaitForCacheSync(stopCh)
+
 	go store.Run(stopCh)
 
 	wait.PollUntil(
@@ -202,9 +205,6 @@ func (f *fixture) run() {
 		},
 		stopCh,
 	)
-
-	informer.Start(stopCh)
-	informer.WaitForCacheSync(stopCh)
 
 	wait.PollUntil(
 		10*time.Millisecond,


### PR DESCRIPTION
The traffic controller needs to be notified of changes to pods, so it
can update the status of TrafficTargets, and make changes to other pods
if necessary. Currently, it relies on a resync of the TrafficTarget to
trigger any changes to pods that need to receive traffic.

If we run shipper without resyncs for long enough, it's possible that
pods will die and be re-scheduled without ever receiving traffic again.

Now, we apply the same technique we used in the other controllers to
watch for events in the application cluster objects.

This closes #206. Do not that this is not by far the desired end state for the traffic controller, as we still need to implement #23.