### PR TITLE
release controller: move cluster choosing to scheduling

### DIFF
--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -386,24 +386,6 @@ func (c *Controller) scheduleRelease(rel *shipper.Release) (*shipper.Release, er
 	)
 	releaseutil.SetReleaseCondition(&rel.Status, *condition)
 
-	if !releaseHasClusters(rel) {
-		shouldForce := false
-		rel, err = scheduler.ChooseClusters(rel, shouldForce)
-
-		if err != nil {
-			return initialRel, err
-		}
-
-		c.recorder.Eventf(
-			rel,
-			corev1.EventTypeNormal,
-			"ClustersSelected",
-			"Set clusters for %q to %v",
-			controller.MetaKey(rel),
-			rel.Annotations[shipper.ReleaseClustersAnnotation],
-		)
-	}
-
 	rel, err = scheduler.ScheduleRelease(rel.DeepCopy())
 	if err != nil {
 		reason := reasonForReleaseCondition(err)


### PR DESCRIPTION
This may or may not make conceptual sense (it does to me, but I could
not find out why choosing clusters and scheduling a release was two
separate steps in the first place, although after #166[1] I'm fairly
convinced this was just a technical artifact), but it sure is
convenient: we move all the error handling during the scheduling step
to a single chunk of code. This fixes an issue where errors in
ChooseClusters were not reflected in any condition, making the Release
object not change during the sync, and therefore not triggering any
events, being essentially invisible to users.

As a bonus, I restored the actual testing part of this in the unit
tests. We were previously just checking that ChooseClusters didn't
trigger any updates, without actually checking if it was doing the right
thing (choosing clusters).

[1] https://github.com/bookingcom/shipper/pull/166/files#diff-caffe52421149f1f8d77a0e7c749867dR327-R341