### PR TITLE
shipper: disable resyncs by default

### DIFF
--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -57,7 +57,7 @@ var controllers = []string{
 }
 
 const defaultRESTTimeout time.Duration = 10 * time.Second
-const defaultResync time.Duration = 30 * time.Second
+const defaultResync time.Duration = 0 * time.Second
 
 var (
 	masterURL           = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")

--- a/kubernetes/shipper.deployment.yaml
+++ b/kubernetes/shipper.deployment.yaml
@@ -32,8 +32,6 @@ spec:
           - "/etc/webhook/certs/tls.key"
           - "-webhook-port"
           - "9443"
-          - "-resync"
-          - "10m"
           - "-v"
           - "4"
           - "-logtostderr"


### PR DESCRIPTION
This has been a long time coming. See #77 and #78 for the
whole saga.

Now that *all* of the know issues with running Shipper with disabled
resyncs have been fixed (after #210 is merged, at least), we firmly
believe that it's beneficial for this to be the default. On a busy cluster,
this makes shipper run much faster, as it's not constantly re-processing
state that hasn't changed, so it has more time to process actual changes,
driving latency much, much lower.

Users that for some reason still require shipper to use resyncs are
still able to configure it through the `-resync` argument, and we intend
on supporting that for the moment.