### PR TITLE
webhook: use listers instead of bare clients

### DIFF
--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -518,7 +518,8 @@ func startWebhook(cfg *cfg) (bool, error) {
 		cfg.webhookBindPort,
 		cfg.webhookKeyPath,
 		cfg.webhookCertPath,
-		client.NewShipperClientOrDie(cfg.restCfg, rolloutblock.AgentName, cfg.restTimeout))
+		client.NewShipperClientOrDie(cfg.restCfg, rolloutblock.AgentName, cfg.restTimeout),
+		cfg.shipperInformerFactory)
 
 	cfg.wg.Add(1)
 	go func() {

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -518,7 +518,7 @@ func startWebhook(cfg *cfg) (bool, error) {
 		cfg.webhookBindPort,
 		cfg.webhookKeyPath,
 		cfg.webhookCertPath,
-		client.NewShipperClientOrDie(cfg.restCfg, rolloutblock.AgentName, cfg.restTimeout),
+		client.NewShipperClientOrDie(cfg.restCfg, webhook.AgentName, cfg.restTimeout),
 		cfg.shipperInformerFactory)
 
 	cfg.wg.Add(1)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -24,6 +24,10 @@ import (
 	"github.com/bookingcom/shipper/pkg/util/rolloutblock"
 )
 
+const (
+	AgentName = "webhook"
+)
+
 type Webhook struct {
 	shipperClientset    clientset.Interface
 	rolloutBlocksLister listers.RolloutBlockLister


### PR DESCRIPTION
During some runs of our e2e tests, we found out that we were hitting
timeouts when operating on objects due to the webhook taking too long to
respond. Since the webhook does very little computational work, our
first suspect is the use of the bare kubeapi client, which issues
network requests.

That's a bit unnecessary, since we already have all the data in memory
anyway, in our informers. So let's use those, or, more specifically, the
listers they give us, so we don't do no network requests no more.