### PR TITLE
anchor: introduce anchor package

### DIFF
--- a/pkg/controller/installation/installer_test.go
+++ b/pkg/controller/installation/installer_test.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
-	"github.com/bookingcom/shipper/pkg/controller/janitor"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+	"github.com/bookingcom/shipper/pkg/util/anchor"
 )
 
 var localFetchChart = func(chartspec *shipper.Chart) (*chart.Chart, error) {
@@ -116,13 +116,10 @@ func ImplTestInstaller(t *testing.T, shipperObjects []runtime.Object, kubeObject
 	testNs := "test-namespace"
 	chart := buildChart(appName, "0.0.1", repoUrl)
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, shipperObjects, objectsPerClusterMap{cluster.Name: kubeObjects})
 
@@ -368,13 +365,10 @@ func TestInstallerSingleServiceNoLB(t *testing.T) {
 	chart := buildChart(appName, "single-service-no-lb", repoUrl)
 
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -419,13 +413,10 @@ func TestInstallerSingleServiceWithLB(t *testing.T) {
 	chart := buildChart(appName, "single-service-with-lb", repoUrl)
 
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -470,13 +461,10 @@ func TestInstallerMultiServiceNoLB(t *testing.T) {
 	chart := buildChart(appName, "multi-service-no-lb", repoUrl)
 
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -484,7 +472,7 @@ func TestInstallerMultiServiceNoLB(t *testing.T) {
 
 	restConfig := &rest.Config{}
 
-	err = installer.install(cluster, fakePair.Client, restConfig, fakeDynamicClientBuilder)
+	err := installer.install(cluster, fakePair.Client, restConfig, fakeDynamicClientBuilder)
 	if err == nil {
 		t.Fatal("Expected an error, none raised")
 	}
@@ -503,13 +491,10 @@ func TestInstallerMultiServiceWithLB(t *testing.T) {
 	chart := buildChart(appName, "multi-service-with-lb", repoUrl)
 
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -558,15 +543,12 @@ func TestInstallerMultiServiceWithLBOffTheShelf(t *testing.T) {
 
 	it := buildInstallationTarget("nginx", "nginx", []string{cluster.Name}, &chart)
 
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 	installer := newInstaller(it)
 	primarySvc := loadService("nginx-primary")
 	secondarySvc := loadService("nginx-secondary")
-	primarySvc.SetOwnerReferences(append(primarySvc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
-	secondarySvc.SetOwnerReferences(append(secondarySvc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	primarySvc.SetOwnerReferences(append(primarySvc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	secondarySvc.SetOwnerReferences(append(secondarySvc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -617,14 +599,11 @@ func TestInstallerServiceWithReleaseNoWorkaround(t *testing.T) {
 	// Disabling the helm workaround
 	delete(it.ObjectMeta.Labels, shipper.HelmWorkaroundLabel)
 
-	configMapAnchor, err := janitor.CreateConfigMapAnchor(it)
-	if err != nil {
-		panic(err)
-	}
+	configMapAnchor := anchor.CreateConfigMapAnchor(it)
 
 	installer := newInstaller(it)
 	svc := loadService("baseline")
-	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), janitor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
+	svc.SetOwnerReferences(append(svc.GetOwnerReferences(), anchor.ConfigMapAnchorToOwnerReference(configMapAnchor)))
 
 	clientsPerCluster, _, fakeDynamicClientBuilder, _ := initializeClients(apiResourceList, nil, objectsPerClusterMap{cluster.Name: nil})
 
@@ -632,7 +611,7 @@ func TestInstallerServiceWithReleaseNoWorkaround(t *testing.T) {
 
 	restConfig := &rest.Config{}
 
-	err = installer.install(cluster, fakePair.Client, restConfig, fakeDynamicClientBuilder)
+	err := installer.install(cluster, fakePair.Client, restConfig, fakeDynamicClientBuilder)
 	if err == nil {
 		t.Fatal("Expected error, none raised")
 	}

--- a/pkg/controller/janitor/janitor_controller_test.go
+++ b/pkg/controller/janitor/janitor_controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+	"github.com/bookingcom/shipper/pkg/util/anchor"
 )
 
 // TestSuccessfulDeleteInstallationTarget exercises syncInstallationTarget(),
@@ -48,18 +49,13 @@ func TestSuccessfulDeleteInstallationTarget(t *testing.T) {
 		fakeClusterClientStore,
 		fakeRecorder)
 
-	anchorName, err := CreateAnchorName(installationTarget)
+	key, err := cache.MetaNamespaceKeyFunc(installationTarget)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(installationTarget); err != nil {
-		t.Fatal(err)
-	}
-
 	item := &InstallationTargetWorkItem{
-		AnchorName: anchorName,
+		AnchorName: anchor.CreateAnchorName(installationTarget),
 		Clusters:   installationTarget.Spec.Clusters,
 		Key:        key,
 		Name:       installationTarget.Name,
@@ -91,10 +87,7 @@ func TestDeleteConfigMapAnchorInstallationTargetMatch(t *testing.T) {
 	installationTarget := loadInstallationTarget()
 
 	// Create a ConfigMap based on the existing installation target object.
-	configMap, err := CreateConfigMapAnchor(installationTarget)
-	if err != nil {
-		t.Fatal(err)
-	}
+	configMap := anchor.CreateConfigMapAnchor(installationTarget)
 
 	// Setup clients with only the existing installation target object, that
 	// will be retrieved and compared by syncAnchor() later on.
@@ -123,8 +116,8 @@ func TestDeleteConfigMapAnchorInstallationTargetMatch(t *testing.T) {
 		fakeClusterClientStore,
 		fakeRecorder)
 
-	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(configMap); err != nil {
+	key, err := cache.MetaNamespaceKeyFunc(configMap)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -158,10 +151,7 @@ func TestDeleteConfigMapAnchorInstallationTargetUIDDoNotMatch(t *testing.T) {
 	cluster := loadCluster("minikube-a")
 	installationTarget := loadInstallationTarget()
 
-	configMap, err := CreateConfigMapAnchor(installationTarget)
-	if err != nil {
-		t.Fatal(err)
-	}
+	configMap := anchor.CreateConfigMapAnchor(installationTarget)
 
 	// Change the installation target object's UID present in the config map.
 	configMap.Data[InstallationTargetUID] = "some-other-installation-target-uid"
@@ -192,8 +182,8 @@ func TestDeleteConfigMapAnchorInstallationTargetUIDDoNotMatch(t *testing.T) {
 		fakeClusterClientStore,
 		fakeRecorder)
 
-	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(configMap); err != nil {
+	key, err := cache.MetaNamespaceKeyFunc(configMap)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -230,10 +220,7 @@ func TestDeleteConfigMapAnchorInstallationTargetDoesNotExist(t *testing.T) {
 	cluster := loadCluster("minikube-a")
 	installationTarget := loadInstallationTarget()
 
-	configMap, err := CreateConfigMapAnchor(installationTarget)
-	if err != nil {
-		t.Fatal(err)
-	}
+	configMap := anchor.CreateConfigMapAnchor(installationTarget)
 
 	// Setup without any extra object in the cache.
 	kubeFakeClientset, shipperFakeClientset, shipperInformerFactory, kubeInformerFactory :=
@@ -261,8 +248,8 @@ func TestDeleteConfigMapAnchorInstallationTargetDoesNotExist(t *testing.T) {
 		fakeClusterClientStore,
 		fakeRecorder)
 
-	var key string
-	if key, err = cache.MetaNamespaceKeyFunc(configMap); err != nil {
+	key, err := cache.MetaNamespaceKeyFunc(configMap)
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/util/filters/filters.go
+++ b/pkg/util/filters/filters.go
@@ -1,10 +1,12 @@
 package filters
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	"github.com/bookingcom/shipper/pkg/util/anchor"
 )
 
 func BelongsToRelease(obj interface{}) bool {
@@ -29,4 +31,14 @@ func BelongsToApp(obj interface{}) bool {
 	_, ok = kubeobj.GetLabels()[shipper.AppLabel]
 
 	return ok
+}
+
+func BelongsToInstallationTarget(obj interface{}) bool {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		klog.Warningf("Received something that's not a corev1/ConfigMap: %v", obj)
+		return false
+	}
+
+	return BelongsToRelease(cm) && anchor.BelongsToInstallationTarget(cm)
 }


### PR DESCRIPTION
It's very weird that a controller was depending on code of another
controller. So I extracted that logic into a neatly independent `anchor`
one, so janitor and installation controller now depend on that instead.

I also took the opportunity to dismantle the pyramid of doom inside the
janitor controller, and start using the `filters` package introduced in
the #219 PR: https://github.com/bookingcom/shipper/pull/219