### PR TITLE
installer: resolve some ownership issues

### DIFF
--- a/pkg/controller/installation/installation_controller_test.go
+++ b/pkg/controller/installation/installation_controller_test.go
@@ -459,7 +459,9 @@ func TestInstallNoOverride(t *testing.T) {
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
 	it.Spec.CanOverride = false
 
-	labels := map[string]string{shipper.InstallationTargetOwnerLabel: appName}
+	labels := map[string]string{
+		shipper.AppLabel:                     appName,
+		shipper.InstallationTargetOwnerLabel: appName}
 	meta := metav1.ObjectMeta{
 		Namespace: testNs,
 		Name:      fmt.Sprintf("%s-%s", appName, appName),

--- a/pkg/controller/installation/installer_test.go
+++ b/pkg/controller/installation/installer_test.go
@@ -655,15 +655,17 @@ func TestInstallerNoOverride(t *testing.T) {
 	it := buildInstallationTarget(testNs, appName, []string{cluster.Name}, &chart)
 	it.Spec.CanOverride = false
 
+	labels := map[string]string{
+		shipper.AppLabel:                     appName,
+		shipper.InstallationTargetOwnerLabel: ownerLabel}
+
 	svc := loadService("baseline")
 	svc.ObjectMeta.Namespace = testNs
-	svc.ObjectMeta.SetLabels(map[string]string{
-		shipper.InstallationTargetOwnerLabel: ownerLabel})
+	svc.ObjectMeta.SetLabels(labels)
 
 	deployment := loadDeployment("baseline")
 	deployment.ObjectMeta.Namespace = testNs
-	deployment.ObjectMeta.SetLabels(map[string]string{
-		shipper.InstallationTargetOwnerLabel: ownerLabel})
+	deployment.ObjectMeta.SetLabels(labels)
 
 	kubeObjects := []runtime.Object{svc, deployment}
 


### PR DESCRIPTION
This resolves two seemingly unrelated issues, but since they both
required changing the same bit of code, I'm combining it into the same
commit.

1. Shipper shouldn't update objects that it didn't create, or that it
created for a different application that happened to have objects with
the same names. This was reported in #98 [1]. If it finds such objects,
it should bail out and let the user know, as it's not possible for
shipper to resolve this on its own.

2. After we removed the migration scaffolding in
9967c55ca22bf013dfe9de25846a297ecd3ad7fe, we didn't account for k8s
objects that might've been left behind from apps that didn't get any new
releases while running shipper v0.6, particularly services. Those would
fail with the following error:

	Object "foo/bar" is missing required label "shipper-owned-by" as
	it was not created by any InstallationTarget. Shipper doesn't
	know how to deal with this

Note how you can't know which Kind we're talking about :) This has also
been addressed in this commit.

[1] https://github.com/bookingcom/shipper/issues/98 - Only replace the
services created by this Application object