### PR TITLE
installer: report the correct error

### DIFF
--- a/pkg/controller/installation/installer.go
+++ b/pkg/controller/installation/installer.go
@@ -543,9 +543,9 @@ func (i *Installer) installManifests(
 		}
 		unstructured.SetNestedField(existingUnstructuredObj, newUnstructuredObj["spec"], "spec")
 		existingObj.SetUnstructuredContent(existingUnstructuredObj)
-		if _, clientErr := resourceClient.Update(existingObj, metav1.UpdateOptions{}); clientErr != nil {
-			return shippererrors.
-				NewKubeclientUpdateError(unstrObj, err).
+
+		if _, err := resourceClient.Update(existingObj, metav1.UpdateOptions{}); err != nil {
+			return shippererrors.NewKubeclientUpdateError(unstrObj, err).
 				WithKind(gvk)
 		}
 	}


### PR DESCRIPTION
We were previously storing the error in `clientErr`, but actually
reporting `err`, which could've been anything. We noticed it when it was
`nil`, triggering all kinds of spurious retries, as any nil error is
retriable.