### PR TITLE
Release executor returns a sorted list of unready clusters

### DIFF
--- a/pkg/controller/release/checks.go
+++ b/pkg/controller/release/checks.go
@@ -1,6 +1,8 @@
 package release
 
 import (
+	"sort"
+
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	replicasutil "github.com/bookingcom/shipper/pkg/util/replicas"
 )
@@ -126,6 +128,9 @@ func checkCapacity(
 			clustersNotReady = append(clustersNotReady, clusterName)
 		}
 	}
+
+	// We need a sorted order, otherwise it will trigger unnecessary etcd update operations
+	sort.Strings(clustersNotReady)
 
 	if len(newSpec.Clusters) > 0 {
 		return canProceed, newSpec, clustersNotReady


### PR DESCRIPTION
Release executor is reported to return an unstable sorting of clusters
that are pending capacity updates. This causes some unnecessary etcd
update operations and pollute the logs. This commit forces stable
sorting of this list.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>