### PR TITLE
Implemented an e2e test reproducing the traffic shifting bug

### DIFF
--- a/test/e2e/e2e_util.go
+++ b/test/e2e/e2e_util.go
@@ -71,6 +71,24 @@ func (f *fixture) checkPods(relName string, expectedCount int) {
 	}
 }
 
+func (f *fixture) checkEndpointActivePods(epName string, podCnt int) {
+	ep, err := kubeClient.CoreV1().Endpoints(f.namespace).Get(epName, metav1.GetOptions{})
+	if err != nil {
+		f.t.Fatalf("could not fetch endpoint %q: %q", epName, err)
+	}
+
+	ips := make([]string, 0, podCnt)
+	for _, subset := range ep.Subsets {
+		for _, addr := range subset.Addresses {
+			ips = append(ips, addr.IP)
+		}
+	}
+
+	if len(ips) != podCnt {
+		f.t.Fatalf("wrong IP address count in the endpoint %q: want: %d, got: %d", epName, len(ips), podCnt)
+	}
+}
+
 func (f *fixture) waitForRelease(appName string, historyIndex int) *shipper.Release {
 	var newRelease *shipper.Release
 	start := time.Now()


### PR DESCRIPTION
This commit implements an e2e test that reproduces the problem with
traffic label shifting observed in shipper 0.7. The scenario it replays:
	1. Create an application
	2. Create first release with 0 replicas and set it to full on
	3. Create second release with 2 replicas and set it to full-on
	4. Inspect the active pods: only 1 pod will contain
	traffic:enabled label, but both pods are expected to be active

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>