### PR TITLE
No release tag in built deployment files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,11 @@ setup: $(SHIPPER_CLUSTERS_YAML) build/shipperctl.$(GOOS)-amd64
 
 # Install shipper in kubernetes, by applying all the required deployment yamls.
 install: install-shipper install-shipper-state-metrics
-install-shipper: build/shipper.image.$(IMAGE_TAG) build/shipper.deployment.$(IMAGE_TAG).yaml
-	$(KUBECTL) apply -f build/shipper.deployment.$(IMAGE_TAG).yaml
+install-shipper: build/shipper.image.$(IMAGE_TAG) build/shipper.deployment.yaml
+	$(KUBECTL) apply -f build/shipper.deployment.yaml
 
-install-shipper-state-metrics: build/shipper-state-metrics.image.$(IMAGE_TAG) build/shipper-state-metrics.deployment.$(IMAGE_TAG).yaml
-	$(KUBECTL) apply -f build/shipper-state-metrics.deployment.$(IMAGE_TAG).yaml
+install-shipper-state-metrics: build/shipper-state-metrics.image.$(IMAGE_TAG) build/shipper-state-metrics.deployment.yaml
+	$(KUBECTL) apply -f build/shipper-state-metrics.deployment.yaml
 
 # Install a helm chart repository server with test charts. This is useful
 # mostly for end-to-end tests.
@@ -151,7 +151,7 @@ clean:
 .PHONY: build-bin build-yaml build-images build-all
 SHA = $(if $(shell which sha256sum),sha256sum,shasum -a 256)
 build-bin: $(foreach bin,$(BINARIES),build/$(bin).$(GOOS)-amd64)
-build-yaml:  build/shipper.deployment.$(IMAGE_TAG).yaml build/shipper-state-metrics.deployment.$(IMAGE_TAG).yaml
+build-yaml:  build/shipper.deployment.yaml build/shipper-state-metrics.deployment.yaml
 build-images: build/shipper.image.$(IMAGE_TAG) build/shipper-state-metrics.image.$(IMAGE_TAG)
 build-all: $(foreach os,$(OS),build/shipperctl.$(os)-amd64.tar.gz) build/sha256sums.txt build-yaml build-images
 
@@ -172,7 +172,7 @@ build/e2e.test: $(PKG) test/e2e/*
 
 IMAGE_NAME_WITH_SHA256 = $(shell cat build/$*.image.$(IMAGE_TAG))
 IMAGE_NAME_TO_USE = $(if $(USE_IMAGE_NAME_WITH_SHA256),$(IMAGE_NAME_WITH_SHA256),$(IMAGE_NAME_WITH_TAG))
-build/%.deployment.$(IMAGE_TAG).yaml: kubernetes/%.deployment.yaml build/%.image.$(IMAGE_TAG) build
+build/%.deployment.yaml: kubernetes/%.deployment.yaml build/%.image.$(IMAGE_TAG) build
 	sed s=\<IMAGE\>=$(IMAGE_NAME_TO_USE)= $< > $@
 
 build/sha256sums.txt: $(foreach os,$(OS),build/shipperctl.$(os)-amd64.tar.gz) 


### PR DESCRIPTION
This commit changes the behavior of the makefile and removes the
release tag from file names. This is mainly done to preserve a
deterministic path to shipper deploy file which is promoited in the
documentation under latest tag. A static deployment file name allows one
to link it with no need to update the relevant documentation on every
build.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>