### PR TITLE
ReleaseController scheduler only keeps 2 recent target pairs

### DIFF
--- a/pkg/controller/capacity/capacity_controller.go
+++ b/pkg/controller/capacity/capacity_controller.go
@@ -2,12 +2,12 @@ package capacity
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -301,7 +301,7 @@ func (c *Controller) capacityTargetSyncHandler(key string) error {
 
 	ct, err := c.processCapacityTarget(initialCT.DeepCopy())
 
-	if !reflect.DeepEqual(initialCT, ct) {
+	if !equality.Semantic.DeepEqual(initialCT, ct) {
 		if _, err := c.shipperclientset.ShipperV1alpha1().CapacityTargets(namespace).Update(ct); err != nil {
 			return shippererrors.NewKubeclientUpdateError(ct, err).
 				WithShipperKind("CapacityTarget")

--- a/pkg/controller/rolloutblock/rolloutblock_release.go
+++ b/pkg/controller/rolloutblock/rolloutblock_release.go
@@ -48,7 +48,9 @@ func (c *Controller) syncRelease(key string) error {
 	}
 	rel, err := c.releaseLister.Releases(ns).Get(name)
 	if err != nil {
-		return err
+		// Wrapping in KubeClientError so the controller can take the
+		// right decision on the error handling (e.g. if it's retriable).
+		return shippererrors.NewKubeclientGetError(ns, name, err)
 	}
 	overrides := rolloutblock.NewObjectNameList(rel.Annotations[shipper.RolloutBlocksOverrideAnnotation])
 	for rbkey := range overrides {

--- a/pkg/controller/traffic/traffic_controller.go
+++ b/pkg/controller/traffic/traffic_controller.go
@@ -2,11 +2,11 @@ package traffic
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -197,7 +197,7 @@ func (c *Controller) syncHandler(key string) error {
 
 	tt, err := c.processTrafficTarget(initialTT.DeepCopy())
 
-	if !reflect.DeepEqual(initialTT, tt) {
+	if !equality.Semantic.DeepEqual(initialTT, tt) {
 		if _, err := c.shipperclientset.ShipperV1alpha1().TrafficTargets(namespace).Update(tt); err != nil {
 			return shippererrors.NewKubeclientUpdateError(tt, err).
 				WithShipperKind("TrafficTarget")

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Semantic can do semantic deep equality checks for api objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
 # k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563
+k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource


### PR DESCRIPTION
This commit introduces a change in release controller scheduler. It
proposes to only keep 2 recent target pairs (e.g. 2 latest capacity
targets, 2 latest traffic targets and 2 latest installation targets).
This is mainly done as a step towards simplifying Shipper's job on
handling accidental wakeups of old releases (see
https://github.com/bookingcom/shipper/issues/71 for more details).

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>