### PR TITLE
ci: upgrade golang, golangci-lint, microk8s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: go
 go:
-- 1.12.x
+- 1.13.x
 sudo: required
 dist: xenial
 services:
 - docker
 before_install:
-- sudo snap install microk8s --classic --channel=1.14/stable
-- curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.3/bin/linux/amd64/kubectl > $(go env GOPATH)/bin/kubectl
+- sudo snap install microk8s --classic --channel=1.15/stable
+- curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.6/bin/linux/amd64/kubectl > $(go env GOPATH)/bin/kubectl
 - chmod +x $(go env GOPATH)/bin/kubectl
 - mkdir ~/.kube
 - sudo microk8s.config > ~/.kube/config
 - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh |
-  sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  sh -s -- -b $(go env GOPATH)/bin v1.21.0
 - sudo microk8s.status --wait-ready
 - sudo microk8s.enable registry
 install: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bookingcom/shipper
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go v0.39.0 // indirect
@@ -54,3 +54,5 @@ require (
 	k8s.io/utils v0.0.0-20190529001817-6999998975a7 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )
+
+replace k8s.io/apimachinery v0.0.0-20190602113612-63a6072eb563 => k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563

--- a/go.sum
+++ b/go.sum
@@ -352,7 +352,6 @@ k8s.io/api v0.0.0-20190602205700-9b8cae951d65/go.mod h1:03pQc5o/sznCJkBfM5JE6PDB
 k8s.io/apiextensions-apiserver v0.0.0-20190602131520-451a9c13a3c8 h1:EqVj1O4rx5Ei3v5GZTc+koIsRr52HEbpKb3hYju+r54=
 k8s.io/apiextensions-apiserver v0.0.0-20190602131520-451a9c13a3c8/go.mod h1:vBDmZGUuVk3xyaO5Y50RRbmbzyUMs4CRtk3yhXuBteg=
 k8s.io/apimachinery v0.0.0-20190531131812-859a0ba5e71a/go.mod h1:u/2VL7tgEMV0FFTV9q0JO+7cnTsV44LP8Pmx41R4AQ4=
-k8s.io/apimachinery v0.0.0-20190602113612-63a6072eb563/go.mod h1:u/2VL7tgEMV0FFTV9q0JO+7cnTsV44LP8Pmx41R4AQ4=
 k8s.io/apimachinery v0.0.0-20190602125621-c0632ccbde11/go.mod h1:u/2VL7tgEMV0FFTV9q0JO+7cnTsV44LP8Pmx41R4AQ4=
 k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563 h1:FqK+g186du3W9peHKCV2GPqMSNEIHz1QUrfYggvaseU=
 k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563/go.mod h1:u/2VL7tgEMV0FFTV9q0JO+7cnTsV44LP8Pmx41R4AQ4=


### PR DESCRIPTION
kubectl and golangci-lint should be entirely transparent, so I won't
dwell on them too much.

One big change here is the move to Go 1.13. I've been running Shipper
locally in this version already, so no issues are expected. Since Go 1.13 now [validates versions](https://tip.golang.org/doc/go1.13#version-validation), we had to fix one of those cases as well.
This closes #230.

The other big one is microk8s. We're confident enough that Shipper is stable
against 1.14, so let's start trying out a newer version to see how we fare.