### PR TITLE
traffic controller: check progression through Endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ install-helm: build/helm.image.$(IMAGE_TAG)
 e2e: install install-helm build/e2e.test
 	./build/e2e.test --e2e --kubeconfig ~/.kube/config \
 		--testcharts http://$(shell $(KUBECTL) get service helm -o jsonpath='{.spec.clusterIP}'):8879 \
-		--progresstimeout=2m --appcluster $(SHIPPER_CLUSTER) \
+		--appcluster $(SHIPPER_CLUSTER) \
 		$(E2E_FLAGS)
 
 # Delete all pods in $(SHIPPER_NAMESPACE), to force kubernetes to spawn new

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	google.golang.org/appengine v1.6.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190602205700-9b8cae951d65
 	k8s.io/apiextensions-apiserver v0.0.0-20190602131520-451a9c13a3c8
 	k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	google.golang.org/appengine v1.6.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190602205700-9b8cae951d65
 	k8s.io/apiextensions-apiserver v0.0.0-20190602131520-451a9c13a3c8
 	k8s.io/apimachinery v0.0.0-20190602183612-63a6072eb563

--- a/pkg/controller/capacity/builder/report_test.go
+++ b/pkg/controller/capacity/builder/report_test.go
@@ -3,26 +3,9 @@ package builder
 import (
 	"testing"
 
-	"github.com/pmezard/go-difflib/difflib"
-	"sigs.k8s.io/yaml"
-
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 )
-
-func yamlDiff(a interface{}, b interface{}) (string, error) {
-	yamlActual, _ := yaml.Marshal(a)
-	yamlExpected, _ := yaml.Marshal(b)
-
-	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(yamlExpected)),
-		B:        difflib.SplitLines(string(yamlActual)),
-		FromFile: "Expected",
-		ToFile:   "Actual",
-		Context:  4,
-	}
-
-	return difflib.GetUnifiedDiffString(diff)
-}
 
 func TestEmptyReport(t *testing.T) {
 
@@ -33,7 +16,7 @@ func TestEmptyReport(t *testing.T) {
 		Owner: shipper.ClusterCapacityReportOwner{Name: ownerName},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}
@@ -74,7 +57,7 @@ func TestReportOneContainerOnePodOneCondition(t *testing.T) {
 		},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}
@@ -120,7 +103,7 @@ func TestReportOneContainerOnePodOneConditionTerminatedWithExitCodeContainer(t *
 		},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}
@@ -163,7 +146,7 @@ func TestReportOneContainerTwoPodsOneCondition(t *testing.T) {
 		},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}
@@ -221,7 +204,7 @@ func TestReportTwoContainersTwoPodsOneCondition(t *testing.T) {
 		},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}
@@ -317,7 +300,7 @@ func TestReportTwoContainersTwoPodsTwoConditions(t *testing.T) {
 		},
 	}
 
-	text, err := yamlDiff(expected, actual)
+	text, err := shippertesting.YamlDiff(expected, actual)
 	if err != nil {
 		t.Errorf("an error occurred: %s", err)
 	}

--- a/pkg/controller/release/executor.go
+++ b/pkg/controller/release/executor.go
@@ -25,7 +25,7 @@ type Executor struct {
 }
 
 func (s *Executor) info(format string, args ...interface{}) {
-	klog.Infof("Release %q: %s", controller.MetaKey(s.contender.release), fmt.Sprintf(format, args...))
+	klog.V(4).Infof("Release %q: %s", controller.MetaKey(s.contender.release), fmt.Sprintf(format, args...))
 }
 
 func (s *Executor) event(obj runtime.Object, format string, args ...interface{}) {

--- a/pkg/controller/release/scheduler.go
+++ b/pkg/controller/release/scheduler.go
@@ -68,7 +68,7 @@ func (s *Scheduler) ChooseClusters(rel *shipper.Release) (*shipper.Release, erro
 	if releaseHasClusters(rel) {
 		return nil, shippererrors.NewUnrecoverableError(fmt.Errorf("release %q has already been assigned to clusters", metaKey))
 	}
-	klog.Infof("Choosing clusters for release %q", metaKey)
+	klog.V(4).Infof("Choosing clusters for release %q", metaKey)
 
 	selector := labels.Everything()
 	allClusters, err := s.clusterLister.List(selector)
@@ -89,8 +89,8 @@ func (s *Scheduler) ChooseClusters(rel *shipper.Release) (*shipper.Release, erro
 
 func (s *Scheduler) ScheduleRelease(rel *shipper.Release) (*shipper.Release, error) {
 	metaKey := controller.MetaKey(rel)
-	klog.Infof("Processing release %q", metaKey)
-	defer klog.Infof("Finished processing %q", metaKey)
+	klog.V(4).Infof("Processing release %q", metaKey)
+	defer klog.V(4).Infof("Finished processing %q", metaKey)
 
 	if !releaseHasClusters(rel) {
 		rel, err := s.ChooseClusters(rel)
@@ -292,7 +292,7 @@ func (s *Scheduler) CreateOrUpdateInstallationTarget(rel *shipper.Release) (*shi
 	}
 
 	if !installationTargetClustersMatch(it, clusters) {
-		klog.Infof("Updating InstallationTarget %q clusters to %s",
+		klog.V(4).Infof("Updating InstallationTarget %q clusters to %s",
 			controller.MetaKey(it),
 			strings.Join(clusters, ","))
 		setInstallationTargetClusters(it, clusters)
@@ -370,7 +370,7 @@ func (s *Scheduler) CreateOrUpdateCapacityTarget(rel *shipper.Release, totalRepl
 	}
 
 	if !capacityTargetClustersMatch(ct, clusters) {
-		klog.Infof("Updating CapacityTarget %q clusters to %s",
+		klog.V(4).Infof("Updating CapacityTarget %q clusters to %s",
 			controller.MetaKey(ct),
 			strings.Join(clusters, ","))
 		setCapacityTargetClusters(ct, clusters, totalReplicaCount)
@@ -448,7 +448,7 @@ func (s *Scheduler) CreateOrUpdateTrafficTarget(rel *shipper.Release) (*shipper.
 	}
 
 	if !trafficTargetClustersMatch(tt, clusters) {
-		klog.Infof("Updating TrafficTarget %q clusters to %s",
+		klog.V(4).Infof("Updating TrafficTarget %q clusters to %s",
 			controller.MetaKey(tt),
 			strings.Join(clusters, ","))
 		setTrafficTargetClusters(tt, clusters)

--- a/pkg/controller/traffic/traffic_controller_test.go
+++ b/pkg/controller/traffic/traffic_controller_test.go
@@ -147,7 +147,7 @@ func (spec TrafficControllerTestSpec) Run(t *testing.T) {
 		tt := object.(*shipper.TrafficTarget)
 
 		actualStatus := tt.Status.Clusters
-		eq, diff := deepEqualDiff(expectation.Statuses, actualStatus)
+		eq, diff := shippertesting.DeepEqualDiff(expectation.Statuses, actualStatus)
 		if !eq {
 			t.Errorf(
 				"TrafficTarget %q has Status.Clusters different from expected:\n%s",

--- a/pkg/controller/traffic/traffic_shifting_status.go
+++ b/pkg/controller/traffic/traffic_shifting_status.go
@@ -1,0 +1,95 @@
+package traffic
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// TODO(jgreff): calculate achieved weight based on pods in the endpoint
+// TODO(jgreff): maybe we don't need the pods themselves in Ready/NotReady
+
+type TrafficShiftingStatus struct {
+	LabeledPods   []*corev1.Pod
+	UnlabeledPods []*corev1.Pod
+
+	ReadyPods    int
+	NotReadyPods int
+
+	ReleasePods int
+
+	AchievedPercentage float64
+
+	podMap          map[string]*corev1.Pod
+	podReadinessMap map[string]bool
+}
+
+func NewTrafficShiftingStatus(
+	pods []*corev1.Pod,
+	endpoints *corev1.Endpoints,
+	trafficSelector labels.Selector,
+	releaseSelector labels.Selector,
+) *TrafficShiftingStatus {
+	status := &TrafficShiftingStatus{
+		podMap:          make(map[string]*corev1.Pod),
+		podReadinessMap: make(map[string]bool),
+	}
+
+	for _, pod := range pods {
+		podLabels := labels.Set(pod.Labels)
+		if !releaseSelector.Matches(podLabels) {
+			continue
+		}
+
+		status.podMap[pod.Name] = pod
+
+		status.ReleasePods++
+
+		if trafficSelector.Matches(podLabels) {
+			status.LabeledPods = append(status.LabeledPods, pod)
+		} else {
+			status.UnlabeledPods = append(status.UnlabeledPods, pod)
+		}
+	}
+
+	for _, subset := range endpoints.Subsets {
+		status.markAddressReadiness(subset.Addresses, true)
+		status.markAddressReadiness(subset.NotReadyAddresses, false)
+	}
+
+	for podName, podReady := range status.podReadinessMap {
+		_, belongsToRelease := status.podMap[podName]
+
+		if !belongsToRelease {
+			continue
+		}
+
+		if podReady {
+			status.ReadyPods++
+		} else {
+			status.NotReadyPods++
+		}
+	}
+
+	status.AchievedPercentage = float64(status.ReadyPods) / float64(len(status.podReadinessMap))
+
+	return status
+}
+
+// markAddressReadiness updates its internal map of pod readiness, by marking
+// the pods from a list of EndpointAddress as either ready or not ready
+// according to the markAs parameter.
+func (s *TrafficShiftingStatus) markAddressReadiness(
+	addresses []corev1.EndpointAddress,
+	markAs bool,
+) {
+	for _, address := range addresses {
+		target := address.TargetRef
+		// Don't know what to do if the target is not a Pod, so
+		// just skip it.
+		if target.Kind != "Pod" {
+			continue
+		}
+
+		s.podReadinessMap[target.Name] = markAs
+	}
+}

--- a/pkg/controller/traffic/utils_test.go
+++ b/pkg/controller/traffic/utils_test.go
@@ -2,14 +2,11 @@ package traffic
 
 import (
 	"fmt"
-	"reflect"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
-	"github.com/pmezard/go-difflib/difflib"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -52,34 +49,6 @@ func shiftPodInEndpoints(pod *corev1.Pod, endpoints *corev1.Endpoints) *corev1.E
 	}
 
 	return endpoints
-}
-
-func yamlDiff(a interface{}, b interface{}) (string, error) {
-	yamlActual, _ := yaml.Marshal(a)
-	yamlExpected, _ := yaml.Marshal(b)
-
-	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(yamlExpected)),
-		B:        difflib.SplitLines(string(yamlActual)),
-		FromFile: "Expected",
-		ToFile:   "Actual",
-		Context:  4,
-	}
-
-	return difflib.GetUnifiedDiffString(diff)
-}
-
-func deepEqualDiff(expected, actual interface{}) (bool, string) {
-	if !reflect.DeepEqual(actual, expected) {
-		diff, err := yamlDiff(actual, expected)
-		if err != nil {
-			panic(fmt.Sprintf("couldn't generate yaml diff: %s", err))
-		}
-
-		return false, diff
-	}
-
-	return true, ""
 }
 
 type ControllerTestFixture struct {

--- a/pkg/controller/traffic/utils_test.go
+++ b/pkg/controller/traffic/utils_test.go
@@ -1,0 +1,135 @@
+package traffic
+
+import (
+	"fmt"
+	"reflect"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
+	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+	"github.com/pmezard/go-difflib/difflib"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+// NOTE: this does not try to implement endpoint subsets at all. All
+// pods are assumed to be part of the same subset and to be always ready.
+func shiftPodInEndpoints(pod *corev1.Pod, endpoints *corev1.Endpoints) *corev1.Endpoints {
+	var podGetsTraffic bool
+	trafficStatusLabel, ok := pod.Labels[shipper.PodTrafficStatusLabel]
+	if ok {
+		podGetsTraffic = trafficStatusLabel == shipper.Enabled
+	}
+
+	addresses := endpoints.Subsets[0].Addresses
+	addressIndex := -1
+	for i, address := range addresses {
+		if address.TargetRef.Name == pod.Name {
+			addressIndex = i
+			break
+		}
+	}
+
+	if podGetsTraffic && addressIndex == -1 {
+		address := corev1.EndpointAddress{
+			TargetRef: &corev1.ObjectReference{
+				Kind:      "Pod",
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			},
+		}
+
+		endpoints.Subsets[0] = corev1.EndpointSubset{
+			Addresses: append(addresses, address),
+		}
+	} else if !podGetsTraffic && addressIndex >= 0 {
+		endpoints.Subsets[0] = corev1.EndpointSubset{
+			Addresses: append(addresses[:addressIndex], addresses[:addressIndex+1]...),
+		}
+	}
+
+	return endpoints
+}
+
+func yamlDiff(a interface{}, b interface{}) (string, error) {
+	yamlActual, _ := yaml.Marshal(a)
+	yamlExpected, _ := yaml.Marshal(b)
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(yamlExpected)),
+		B:        difflib.SplitLines(string(yamlActual)),
+		FromFile: "Expected",
+		ToFile:   "Actual",
+		Context:  4,
+	}
+
+	return difflib.GetUnifiedDiffString(diff)
+}
+
+func deepEqualDiff(expected, actual interface{}) (bool, string) {
+	if !reflect.DeepEqual(actual, expected) {
+		diff, err := yamlDiff(actual, expected)
+		if err != nil {
+			panic(fmt.Sprintf("couldn't generate yaml diff: %s", err))
+		}
+
+		return false, diff
+	}
+
+	return true, ""
+}
+
+type ControllerTestFixture struct {
+	ShipperClient          *shipperfake.Clientset
+	ShipperInformerFactory shipperinformers.SharedInformerFactory
+
+	Clusters           map[string]*shippertesting.FakeCluster
+	ClusterClientStore *shippertesting.FakeClusterClientStore
+
+	Recorder *record.FakeRecorder
+}
+
+func NewControllerTestFixture() *ControllerTestFixture {
+	const recorderBufSize = 42
+
+	shipperClient := shipperfake.NewSimpleClientset()
+	shipperInformerFactory := shipperinformers.NewSharedInformerFactory(
+		shipperClient, shippertesting.NoResyncPeriod)
+
+	store := shippertesting.NewFakeClusterClientStore(map[string]*shippertesting.FakeCluster{})
+
+	return &ControllerTestFixture{
+		ShipperClient:          shipperClient,
+		ShipperInformerFactory: shipperInformerFactory,
+
+		Clusters:           make(map[string]*shippertesting.FakeCluster),
+		ClusterClientStore: store,
+
+		Recorder: record.NewFakeRecorder(recorderBufSize),
+	}
+}
+
+func (f *ControllerTestFixture) AddNamedCluster(name string) *shippertesting.FakeCluster {
+	cluster := shippertesting.NewNamedFakeCluster(
+		name,
+		kubefake.NewSimpleClientset(), nil)
+
+	f.Clusters[cluster.Name] = cluster
+	f.ClusterClientStore.AddCluster(cluster)
+
+	return cluster
+}
+
+func (f *ControllerTestFixture) AddCluster() *shippertesting.FakeCluster {
+	name := fmt.Sprintf("cluster-%d", len(f.Clusters))
+	return f.AddNamedCluster(name)
+}
+
+func (f *ControllerTestFixture) Run(stopCh chan struct{}) {
+	f.ShipperInformerFactory.Start(stopCh)
+	f.ShipperInformerFactory.WaitForCacheSync(stopCh)
+	f.ClusterClientStore.Run(stopCh)
+}

--- a/pkg/errors/traffic.go
+++ b/pkg/errors/traffic.go
@@ -52,7 +52,6 @@ func NewMissingTrafficWeightsForClusterError(ns, appName, clusterName string) Mi
 }
 
 type MissingTargetClusterSelectorError struct {
-	clusterName string
 	ns          string
 	serviceName string
 }
@@ -63,13 +62,12 @@ func (e MissingTargetClusterSelectorError) ShouldRetry() bool {
 
 func (e MissingTargetClusterSelectorError) Error() string {
 	return fmt.Sprintf(
-		"cluster error (%q): service %s/%s does not have a selector set. this means we cannot do label-based canary deployment",
-		e.clusterName, e.ns, e.serviceName)
+		"service %s/%s does not have a selector set. this means we cannot do label-based canary deployment",
+		e.ns, e.serviceName)
 }
 
-func NewTargetClusterServiceMissesSelectorError(clusterName, ns, serviceName string) MissingTargetClusterSelectorError {
+func NewTargetClusterServiceMissesSelectorError(ns, serviceName string) MissingTargetClusterSelectorError {
 	return MissingTargetClusterSelectorError{
-		clusterName: clusterName,
 		ns:          ns,
 		serviceName: serviceName,
 	}

--- a/pkg/testing/fakeclusterclientstore.go
+++ b/pkg/testing/fakeclusterclientstore.go
@@ -24,6 +24,10 @@ func NewFakeClusterClientStore(clusters map[string]*FakeCluster) *FakeClusterCli
 	return &FakeClusterClientStore{clusters: clusters}
 }
 
+func (s *FakeClusterClientStore) AddCluster(c *FakeCluster) {
+	s.clusters[c.Name] = c
+}
+
 func (s *FakeClusterClientStore) AddSubscriptionCallback(c clusterclientstore.SubscriptionRegisterFunc) {
 	s.subscriptionCallbacks = append(s.subscriptionCallbacks, c)
 }

--- a/pkg/testing/util.go
+++ b/pkg/testing/util.go
@@ -133,17 +133,17 @@ func FilterActions(actions []kubetesting.Action) []kubetesting.Action {
 		for _, v := range []string{"list", "watch"} {
 			for _, r := range []string{
 				"applications",
-				"shipmentorders",
-				"releases",
-				"clusters",
-				"secrets",
-				"installationtargets",
-				"traffictargets",
 				"capacitytargets",
+				"clusters",
 				"deployments",
-				"services",
+				"endpoints",
+				"installationtargets",
 				"pods",
+				"releases",
 				"rolloutblocks",
+				"secrets",
+				"services",
+				"traffictargets",
 			} {
 				if action.Matches(v, r) {
 					return true

--- a/pkg/testing/util.go
+++ b/pkg/testing/util.go
@@ -204,6 +204,13 @@ func prettyPrintAction(a kubetesting.Action) string {
 		message := fmt.Sprintf("(no object body: GET %s)", action.GetName())
 		return fmt.Sprintf(template, message)
 
+	case kubetesting.ListActionImpl:
+		message := fmt.Sprintf("(no object body: GET %s)", action.GetKind())
+		return fmt.Sprintf(template, message)
+
+	case kubetesting.WatchActionImpl:
+		return fmt.Sprintf(template, "(no object body: WATCH)")
+
 	case kubetesting.DeleteActionImpl:
 		message := fmt.Sprintf("(no object body: DELETE %s)", action.GetName())
 		return fmt.Sprintf(template, message)


### PR DESCRIPTION
Our current traffic controller considers a Pod being successfully
patched to have traffic labels as traffic actually progressing.

This isn't reliable for several reasons:

* A Service's `.spec.selector` can be modified, resulting in Pods no
longer receiving traffic, but the traffic controller will still report
that traffic has been achieved.

* Pods can be in a non-Ready state, making them not receive traffic, and
again Shipper will report traffic as being achieved.

To solve both of those issues, we now watch endpoints and extract actual
traffic information from them. For our purposes, only Ready Pods will
count towards traffic. This might make rollouts slightly slower (as
traffic now has to wait for pods to be actually ready to receive
traffic) but also much more reliable: we won't drain traffic from an
incumbent Release until the contender is actually fully ready.

Closes #23.