### PR TITLE
traffic controller: report the correct achieved traffic weight

### DIFF
--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -12,7 +12,7 @@ TEST_STATUS=$?
 rm -f build/*.latest.yaml
 
 # Output all of the logs from the shipper pod, for reference
-kubectl -n shipper-system logs -l app=shipper --tail=-1
+kubectl -n shipper-system logs $(kubectl -n shipper-system get pod -l app=shipper -o jsonpath='{.items[0].metadata.name}')
 
 # Exit with the exit code we got from the e2e tests
 exit $TEST_STATUS

--- a/pkg/controller/traffic/pod_label_shifter.go
+++ b/pkg/controller/traffic/pod_label_shifter.go
@@ -3,206 +3,62 @@ package traffic
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
-	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
-type podLabelShifter struct {
-	appName               string
-	releaseName           string
-	namespace             string
-	clusterReleaseWeights clusterReleaseWeights
+// patchOperation represents a JSON PatchOperation in a very specific way.
+// Using jsonpatch's types could be a possiblity, but there's no need to be
+// generic in here.
+type patchOperation struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
 }
 
-type clusterReleaseWeights map[string]map[string]uint32
-
-func newPodLabelShifter(
-	appName string,
-	releaseName string,
-	namespace string,
-	trafficTargets []*shipper.TrafficTarget,
-) (*podLabelShifter, error) {
-	weights, err := buildClusterReleaseWeights(trafficTargets)
-	if err != nil {
-		return nil, err
-	}
-
-	return &podLabelShifter{
-		appName:               appName,
-		releaseName:           releaseName,
-		namespace:             namespace,
-		clusterReleaseWeights: weights,
-	}, nil
-}
-
-func (p *podLabelShifter) SyncCluster(
-	cluster string,
+// shiftPodLabels ensures that the pods in podsToShift have the
+// shipper.PodTrafficStatusLabel label set to the specified values.
+func shiftPodLabels(
 	clientset kubernetes.Interface,
-	informerFactory kubeinformers.SharedInformerFactory,
-) (uint32, error) {
-	releaseTargetWeights, ok := p.clusterReleaseWeights[cluster]
-	if !ok {
-		return 0, shippererrors.NewMissingTrafficWeightsForClusterError(
-			p.namespace, p.appName, cluster)
-	}
-
-	podLister := informerFactory.Core().V1().Pods().Lister().Pods(p.namespace)
-	podGVK := corev1.SchemeGroupVersion.WithKind("Pod")
-
-	appSelector := labels.Set{shipper.AppLabel: p.appName}.AsSelector()
-	appPods, err := podLister.List(appSelector)
-	if err != nil {
-		return 0, shippererrors.NewKubeclientListError(
-			podGVK, p.namespace, appSelector, err)
-	}
-
-	releaseSelector := labels.Set{shipper.ReleaseLabel: p.releaseName}.AsSelector()
-
-	svc, err := p.getService(informerFactory)
-	if err != nil {
-		return 0, err
-	} else if svc.Spec.Selector == nil {
-		return 0, shippererrors.NewTargetClusterServiceMissesSelectorError(p.namespace, svc.Name)
-	}
-
-	trafficSelector := labels.Set(svc.Spec.Selector).AsSelector()
-
-	endpoints, err := informerFactory.Core().V1().Endpoints().Lister().
-		Endpoints(svc.Namespace).Get(svc.Name)
-	if err != nil {
-		return 0, shippererrors.NewKubeclientGetError(svc.Namespace, svc.Name, err).
-			WithCoreV1Kind("Endpoints")
-	}
-
-	status := NewTrafficShiftingStatus(appPods, endpoints, trafficSelector, releaseSelector)
-
-	var totalTargetWeight uint32 = 0
-	for _, weight := range releaseTargetWeights {
-		totalTargetWeight += weight
-	}
-
-	releaseTargetWeight := releaseTargetWeights[p.releaseName]
-	targetPods := calculateReleasePodTarget(
-		status.ReleasePods, releaseTargetWeight, len(appPods), totalTargetWeight)
-
-	// TODO(jgreff): we need to be able to tell, from the outside, that all
-	// pods have been labeled, but some may not be ready yet.
-
-	if len(status.LabeledPods) != targetPods {
-		err = p.shiftLabels(status, targetPods, clientset)
-		if err != nil {
-			return 0, err
-		}
-
-		achievedWeight := uint32(math.Round(status.AchievedPercentage * float64(totalTargetWeight)))
-		return achievedWeight, nil
-	} else {
-		return releaseTargetWeight, nil
-	}
-}
-
-func (p *podLabelShifter) shiftLabels(
-	status *TrafficShiftingStatus,
-	targetPods int,
-	clientset kubernetes.Interface,
+	podsToShift map[string][]*corev1.Pod,
 ) error {
-	patches := make(map[string][]byte)
-
-	if len(status.LabeledPods) > targetPods {
-		excess := len(status.LabeledPods) - targetPods
-
-		for i := 0; i < excess; i++ {
-			pod := status.LabeledPods[i].DeepCopy()
-
-			value, ok := pod.Labels[shipper.PodTrafficStatusLabel]
-			if !ok || value == shipper.Enabled {
-				patches[pod.Name] = patchPodTrafficStatusLabel(pod, shipper.Disabled)
+	for value, pods := range podsToShift {
+		for _, pod := range pods {
+			v, ok := pod.Labels[shipper.PodTrafficStatusLabel]
+			if ok && v == value {
+				continue
 			}
-		}
-	} else {
-		missing := targetPods - len(status.LabeledPods)
 
-		if missing > len(status.UnlabeledPods) {
-			return shippererrors.NewTargetClusterMathError(p.releaseName, len(status.UnlabeledPods), missing)
-		}
-
-		for i := 0; i < missing; i++ {
-			pod := status.UnlabeledPods[i].DeepCopy()
-
-			value, ok := pod.Labels[shipper.PodTrafficStatusLabel]
-			if !ok || ok && value == shipper.Disabled {
-				patches[pod.Name] = patchPodTrafficStatusLabel(pod, shipper.Enabled)
+			patch := patchPodTrafficStatusLabel(pod, value)
+			_, err := clientset.CoreV1().Pods(pod.Namespace).
+				Patch(pod.Name, types.JSONPatchType, patch)
+			if err != nil {
+				return shippererrors.
+					NewKubeclientPatchError(pod.Namespace, pod.Name, err).
+					WithCoreV1Kind("Pod")
 			}
-		}
-	}
-
-	podsClient := clientset.CoreV1().Pods(p.namespace)
-	for podName, patch := range patches {
-		_, err := podsClient.Patch(podName, types.JSONPatchType, patch)
-		if err != nil {
-			return shippererrors.
-				NewKubeclientPatchError(p.namespace, podName, err).
-				WithCoreV1Kind("Pod")
 		}
 	}
 
 	return nil
 }
 
-func (p *podLabelShifter) getService(
-	informerFactory kubeinformers.SharedInformerFactory,
-) (*corev1.Service, error) {
-	serviceSelector := labels.Set(map[string]string{
-		shipper.AppLabel: p.appName,
-		shipper.LBLabel:  shipper.LBForProduction,
-	}).AsSelector()
-
-	gvk := corev1.SchemeGroupVersion.WithKind("Service")
-	services, err := informerFactory.Core().V1().Services().Lister().
-		Services(p.namespace).List(serviceSelector)
-	if err != nil {
-		return nil, shippererrors.NewKubeclientListError(
-			gvk, p.namespace, serviceSelector, err)
-	}
-
-	if n := len(services); n != 1 {
-		return nil, shippererrors.NewUnexpectedObjectCountFromSelectorError(
-			serviceSelector, gvk, 1, n)
-	}
-
-	return services[0], nil
-}
-
-// PatchOperation represents a JSON PatchOperation in a very specific way.
-// Using jsonpatch's types could be a possiblity, but there's no need to be
-// generic in here.
-type PatchOperation struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value string `json:"value"`
-}
-
 // patchPodTrafficStatusLabel returns a JSON Patch that modifies the
 // PodTrafficStatusLabel value of a given Pod.
 func patchPodTrafficStatusLabel(pod *corev1.Pod, value string) []byte {
 	var op string
-
 	if _, ok := pod.Labels[shipper.PodTrafficStatusLabel]; ok {
 		op = "replace"
 	} else {
 		op = "add"
 	}
 
-	patchList := []PatchOperation{
+	patchList := []patchOperation{
 		{
 			Op:    op,
 			Path:  fmt.Sprintf("/metadata/labels/%s", shipper.PodTrafficStatusLabel),
@@ -216,73 +72,4 @@ func patchPodTrafficStatusLabel(pod *corev1.Pod, value string) []byte {
 	patchBytes, _ := json.Marshal(patchList)
 
 	return patchBytes
-}
-
-func calculateReleasePodTarget(releasePods int, releaseWeight uint32, totalPods int, totalWeight uint32) int {
-	// What percentage of the entire fleet (across all releases) should this set of
-	// pods represent.
-	var targetPercent float64
-	if totalWeight == 0 {
-		targetPercent = 0
-	} else {
-		targetPercent = float64(releaseWeight) / float64(totalWeight) * 100
-	}
-	// Round up to the nearest pod, clamped to the number of pods this release has.
-	targetPods := int(replicas.CalculateDesiredReplicaCount(uint(totalPods), float64(targetPercent)))
-
-	targetPods = int(
-		math.Min(
-			float64(releasePods),
-			float64(targetPods),
-		),
-	)
-	return targetPods
-}
-
-/*
-	Transform this (a list of each release's traffic target object in this namespace):
-	[
-		{ tt-reviewsapi-1: { cluster-1: 90 } },
-		{ tt-reviewsapi-2: { cluster-1: 5 } },
-		{ tt-reviewsapi-3: { cluster-1: 5 } },
-	]
-
-	Into this (a map of release weight per cluster):
-	{
-		cluster-1: {
-			reviewsapi-1: 90,
-			reviewsapi-2: 5,
-			reviewsapi-3: 5,
-		}
-	}
-*/
-func buildClusterReleaseWeights(trafficTargets []*shipper.TrafficTarget) (clusterReleaseWeights, error) {
-	clusterReleases := map[string]map[string]uint32{}
-	releaseTT := map[string]*shipper.TrafficTarget{}
-
-	for _, tt := range trafficTargets {
-		release, ok := tt.Labels[shipper.ReleaseLabel]
-		if !ok {
-			err := shippererrors.NewMissingShipperLabelError(tt, shipper.ReleaseLabel)
-			return nil, err
-		}
-
-		existingTT, ok := releaseTT[release]
-		if ok {
-			return nil, shippererrors.NewMultipleTrafficTargetsForReleaseError(
-				tt.Namespace, release, []string{tt.Name, existingTT.Name})
-		}
-		releaseTT[release] = tt
-
-		for _, cluster := range tt.Spec.Clusters {
-			weights, ok := clusterReleases[cluster.Name]
-			if !ok {
-				weights = map[string]uint32{}
-				clusterReleases[cluster.Name] = weights
-			}
-			weights[release] += cluster.Weight
-		}
-	}
-
-	return clusterReleaseWeights(clusterReleases), nil
 }

--- a/pkg/controller/traffic/pod_label_shifter_test.go
+++ b/pkg/controller/traffic/pod_label_shifter_test.go
@@ -1,481 +1,87 @@
 package traffic
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubeinformers "k8s.io/client-go/informers"
-	kubefake "k8s.io/client-go/kubernetes/fake"
-	clienttesting "k8s.io/client-go/testing"
-
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-const (
-	testClusterName     = "test-cluster"
-	testServiceName     = "test-service"
-	testApplicationName = "test-app"
-)
-
-type releaseWeights []uint32
-type releasePodCounts []int
-type releaseExpectedTrafficPods []int
-type releaseExpectedWeights []uint32
-
-func TestSyncCluster(t *testing.T) {
-	// The 'no release' case doesn't work, and also doesn't make sense.
-	clusterSyncTestCase(t, "one empty release",
-		releaseWeights{0},
-		releasePodCounts{0},
-		releaseExpectedTrafficPods{0},
-		releaseExpectedWeights{0},
-	)
-
-	clusterSyncTestCase(t, "one no-weight release",
-		releaseWeights{0},
-		releasePodCounts{1},
-		releaseExpectedTrafficPods{0},
-		releaseExpectedWeights{0},
-	)
-
-	clusterSyncTestCase(t, "one normal release",
-		releaseWeights{1},
-		releasePodCounts{10},
-		releaseExpectedTrafficPods{10},
-		releaseExpectedWeights{1},
-	)
-
-	clusterSyncTestCase(t, "two empty releases",
-		releaseWeights{0, 0},
-		releasePodCounts{0, 0},
-		releaseExpectedTrafficPods{0, 0},
-		releaseExpectedWeights{0, 0},
-	)
-
-	clusterSyncTestCase(t, "two no-weight",
-		releaseWeights{0, 0},
-		releasePodCounts{1, 1},
-		releaseExpectedTrafficPods{0, 0},
-		releaseExpectedWeights{0, 0},
-	)
-
-	clusterSyncTestCase(t, "two equal releases",
-		releaseWeights{2, 2},
-		releasePodCounts{10, 10},
-		// 2/4 * 20 (total pods) = 10 pods
-		releaseExpectedTrafficPods{10, 10},
-		releaseExpectedWeights{2, 2},
-	)
-
-	clusterSyncTestCase(t, "five equal releases",
-		releaseWeights{1, 1, 1, 1, 1},
-		releasePodCounts{10, 10, 10, 10, 10},
-		// 1/5 * 50 (total pods) = 10 pods
-		releaseExpectedTrafficPods{10, 10, 10, 10, 10},
-		releaseExpectedWeights{1, 1, 1, 1, 1},
-	)
-
-	clusterSyncTestCase(t, "UNequal weight, equal pods",
-		releaseWeights{1, 2},
-		releasePodCounts{10, 10},
-		// 1/3 * 20 (total pods) = 6.66 -> round up to 7 pods
-		releaseExpectedTrafficPods{7, 10},
-		releaseExpectedWeights{1, 2},
-	)
-
-	clusterSyncTestCase(t, "massive weight disparity, equal pods",
-		releaseWeights{1, 10000},
-		releasePodCounts{10, 10},
-		// 1/10001 * 20 (total pods) = 0.00198 -> round up to 1 pod
-		releaseExpectedTrafficPods{1, 10},
-		// 0.05 (1 pod / 20 total pods) * 10001 (total weight) = 500.05 rounds to 500 achieved weight for release 0
-		// 0.5 (10 pods / 20 total pods) * 10001 (total weight) = 5000.5 rounds to 5001 achieved weight for release 1
-		releaseExpectedWeights{500, 5001},
-	)
-
-	clusterSyncTestCase(t, "no rounding, cap on larger weight (too few pods)",
-		releaseWeights{3, 7},
-		releasePodCounts{50, 50},
-		releaseExpectedTrafficPods{30, 50},
-		// 0.3 (30 pods / 100 total pods) * 10 (total weight) = 3 achieved weight for release 0
-		// 0.5 (50 pods / 100 total pods) * 10 (total weight) = 5 achieved weight for release 1
-		releaseExpectedWeights{3, 5},
-	)
-
-	clusterSyncTestCase(t, "uneven pod counts, equal weights",
-		releaseWeights{100, 100},
-		releasePodCounts{10, 1},
-		// 1/2 * 11 (total pods) = 5.5 -> round up to 6 pods
-		// 1/2 * 1 = 0.5 -> round up to 1 pod
-		releaseExpectedTrafficPods{6, 1},
-		// 0.54 (6 pods / 11 total pods) * 200 (total weight) = 109.09 rounds to 109 achieved weight for release 0
-		// 0.09 (1 pod / 11 total pods) * 200 (total weight) = 18 achieved weight for release 1
-		releaseExpectedWeights{109, 18},
-	)
-
-	clusterSyncTestCase(t, "one empty / one present",
-		releaseWeights{0, 1},
-		releasePodCounts{10, 10},
-		// 0/1 * 20 (total pods) = 0 pods
-		releaseExpectedTrafficPods{0, 10},
-		releaseExpectedWeights{0, 1},
-	)
-}
-
-func TestWeightCalculatedForJustOneApplication(t *testing.T) {
-	var weight uint32 = 100
-	pods := 2
-	f := newPodLabelShifterFixture(t, "test unmanaged pods not in weight calculation")
-	f.addService()
-
-	f.addTrafficTarget("release-a", weight)
-	f.addPods("release-a", pods)
-
-	f.addTrafficTarget("release-b", weight)
-	f.addPods("release-b", pods)
-
-	expectedWeightsByName := map[string]uint32{
-		"release-a": weight,
-		"release-b": weight,
-	}
-
-	foreignAppLabels := map[string]string{
-		shipper.ReleaseLabel: "blorg",
-		shipper.AppLabel:     "someOtherApp",
-	}
-	// add a pod for an unrelated application
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "someOtherPod",
-			Namespace: shippertesting.TestNamespace,
-			Labels:    foreignAppLabels,
+func TestShiftPodLabels(t *testing.T) {
+	lbl := shipper.PodTrafficStatusLabel
+	podsToShift := map[string][]*corev1.Pod{
+		shipper.Enabled: {
+			pod("empty-to-enabled", map[string]string{}),
+			pod("enabled-to-enabled", map[string]string{lbl: shipper.Enabled}),
+			pod("disabled-to-enabled", map[string]string{lbl: shipper.Disabled}),
+			pod("misc-to-enabled", map[string]string{"foo": "bar"}),
+		},
+		shipper.Disabled: {
+			pod("empty-to-disabled", map[string]string{}),
+			pod("enabled-to-disabled", map[string]string{lbl: shipper.Enabled}),
+			pod("disabled-to-disabled", map[string]string{lbl: shipper.Disabled}),
+			pod("misc-to-disabled", map[string]string{"foo": "bar"}),
+		},
+		"foobar": {
+			pod("empty-to-foobar", map[string]string{}),
 		},
 	}
 
-	f.objects = append(f.objects, pod)
-	f.pods = append(f.pods, pod)
-
-	f.run(expectedWeightsByName)
-}
-
-func clusterSyncTestCase(
-	t *testing.T,
-	name string,
-	weights releaseWeights,
-	podCounts releasePodCounts,
-	expectedTrafficCounts releaseExpectedTrafficPods,
-	expectedWeights releaseExpectedWeights,
-) {
-	if len(weights) != len(podCounts) || len(weights) != len(expectedTrafficCounts) || len(weights) != len(expectedWeights) {
-		// Programmer error.
-		panic(
-			fmt.Sprintf(
-				"len() of weights (%d), podCounts (%d), expectedWeights (%d) and expectedTrafficCounts (%d) must be == in every test case",
-				len(weights), len(podCounts), len(expectedWeights), len(expectedTrafficCounts),
-			),
-		)
-	}
-
-	releaseNames := make([]string, 0, len(weights))
-	for i := range weights {
-		releaseNames = append(releaseNames, fmt.Sprintf("release-%d", i))
-	}
-
-	f := newPodLabelShifterFixture(t, name)
-
-	for i, weight := range weights {
-		f.addTrafficTarget(releaseNames[i], weight)
-	}
-
-	for i, podCount := range podCounts {
-		f.addPods(releaseNames[i], podCount)
-	}
-
-	expectedWeightsByName := map[string]uint32{}
-	for i, _ := range expectedWeights {
-		// TODO(jgreff): giant hack alert: due to the current state of
-		// the traffic controller, it expects to be lied to about
-		// actually achieved weight: it has to be what's specified as
-		// the target weight. That's obviously not the actual achieved
-		// weight, as this test used to verify. We do want to have the
-		// traffic controller report the correct values, so we intend
-		// to restore these tests to their old correct self as well,
-		// once that's been fixed.
-		expectedWeightsByName[releaseNames[i]] = weights[i]
-		// expectedWeightsByName[releaseNames[i]] = expectedWeight
-	}
-
-	f.addService()
-	keepTesting := f.run(expectedWeightsByName)
-
-	if keepTesting {
-		for i, expectedPodsWithTraffic := range expectedTrafficCounts {
-			f.checkReleasePodsWithTraffic(releaseNames[i], expectedPodsWithTraffic)
+	clientset := kubefake.NewSimpleClientset()
+	tracker := clientset.Tracker()
+	for _, pods := range podsToShift {
+		for _, pod := range pods {
+			tracker.Add(pod)
 		}
 	}
-}
 
-type podLabelShifterFixture struct {
-	t              *testing.T
-	name           string
-	svc            *corev1.Service
-	endpoints      *corev1.Endpoints
-	client         *kubefake.Clientset
-	objects        []runtime.Object
-	pods           []*corev1.Pod
-	trafficTargets []*shipper.TrafficTarget
-	informers      kubeinformers.SharedInformerFactory
-}
-
-func newPodLabelShifterFixture(t *testing.T, name string) *podLabelShifterFixture {
-	f := &podLabelShifterFixture{t: t, name: name}
-	return f
-}
-
-func (f *podLabelShifterFixture) Errorf(template string, args ...interface{}) {
-	argsWithName := make([]interface{}, 0, len(args)+1)
-	argsWithName = append(argsWithName, f.name)
-	argsWithName = append(argsWithName, args...)
-	f.t.Errorf("%s: "+template, argsWithName...)
-}
-
-// each TT pertains to exactly one release
-func (f *podLabelShifterFixture) addTrafficTarget(release string, weight uint32) {
-	tt := newTrafficTarget(release, map[string]uint32{
-		testClusterName: weight,
-	})
-	f.trafficTargets = append(f.trafficTargets, tt)
-}
-
-func (f *podLabelShifterFixture) addPods(releaseName string, count int) {
-	for _, pod := range newReleasePods(releaseName, count) {
-		f.objects = append(f.objects, pod)
-		f.pods = append(f.pods, pod)
-	}
-}
-
-func (f *podLabelShifterFixture) addService() {
-	labels := map[string]string{
-		shipper.AppLabel: testApplicationName,
-		shipper.LBLabel:  shipper.LBForProduction,
-	}
-
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testServiceName,
-			Namespace: shippertesting.TestNamespace,
-			Labels:    labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				shipper.AppLabel:              testApplicationName,
-				shipper.PodTrafficStatusLabel: shipper.Enabled,
-			},
-		},
-	}
-
-	endpoints := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testServiceName,
-			Namespace: shippertesting.TestNamespace,
-			Labels:    labels,
-		},
-		Subsets: []corev1.EndpointSubset{
-			corev1.EndpointSubset{
-				Addresses: []corev1.EndpointAddress{},
-			},
-		},
-	}
-
-	f.svc = svc
-	f.endpoints = endpoints
-	f.objects = append(f.objects, svc, endpoints)
-}
-
-// buildPodPatchReactionFunc returns a ReactionFunc specialized in poorly patch
-// Pods for the scope of the pod label shifter tests.
-//
-// This function is odd but is required since the default object tracker used by
-// Kubernetes fake.Clientset doesn't support Patch actions (see
-// vendor/k8s.io/client-go/testing/fixture.go:67)
-func (f *podLabelShifterFixture) buildPodPatchReactionFunc() clienttesting.ReactionFunc {
-	return func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-		ns := action.GetNamespace()
-
-		switch action := action.(type) {
-		case clienttesting.PatchActionImpl:
-			pod, err := f.informers.Core().V1().Pods().Lister().Pods(ns).Get(action.GetName())
-			if err != nil {
-				return false, nil, err
-			}
-
-			var patchList []PatchOperation
-			err = json.Unmarshal(action.GetPatch(), &patchList)
-			if err != nil {
-				return false, nil, err
-			}
-
-			for _, p := range patchList {
-				// For this particular situation, we don't care whether it is an
-				// add or replace op, although JSON Patch *requires* the key to
-				// exist in order to issue a replace; that's the reason that
-				// patchPodTrafficStatusLabel determines the operation based on
-				// the presence of the PodTrafficStatusLabel.
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", shipper.PodTrafficStatusLabel) {
-					pod.Labels[shipper.PodTrafficStatusLabel] = p.Value
-				}
-			}
-
-			f.endpoints = shiftPodInEndpoints(pod, f.endpoints)
-
-			// Inform the reaction chain the action has been handled, together
-			// with the patched Pod object.
-			return true, pod, nil
-
-		default:
-			return false, nil, nil
-		}
-	}
-}
-
-func (f *podLabelShifterFixture) run(expectedWeights map[string]uint32) bool {
-	clientset := kubefake.NewSimpleClientset(f.objects...)
-	f.client = clientset
-
-	informers := kubeinformers.NewSharedInformerFactory(f.client, shippertesting.NoResyncPeriod)
-	f.informers = informers
-
-	// fake.Clientset default object tracker's Reactor doesn't support "patch"
-	// verbs, thus we provide a reactor that attemps to handle it in a very
-	// specific and somehow naive way.
-	clientset.Fake.PrependReactor("patch", "pods", f.buildPodPatchReactionFunc())
-
-	// Let's get all the informers started and synced
-	stopCh := make(<-chan struct{})
-	informers.Core().V1().Pods().Informer()
-	informers.Core().V1().Services().Informer()
-	informers.Core().V1().Endpoints().Informer()
-	informers.Start(stopCh)
-	informers.WaitForCacheSync(stopCh)
-
-	achievedWeights := make(map[string]uint32)
-
-	for release, _ := range expectedWeights {
-		shifter, err := newPodLabelShifter(
-			testApplicationName,
-			release,
-			shippertesting.TestNamespace,
-			f.trafficTargets,
-		)
-		if err != nil {
-			f.Errorf("failed to create labelShifter: %s", err.Error())
-			return false
-		}
-
-		// NOTE(jgreff): the first run of SyncCluster will only adjust
-		// pods and return the previously achieved weight. A second run
-		// will return the new achieved weight, presumably after pods
-		// have made it to the endpoint.
-		shifter.SyncCluster(testClusterName, f.client, informers)
-		achieved, err := shifter.SyncCluster(testClusterName, f.client, informers)
-
-		if err != nil {
-			f.Errorf("failed to sync cluster: %s", err.Error())
-			return false
-		}
-
-		achievedWeights[release] = achieved
-	}
-
-	keepTesting := true
-	for release, expectedWeight := range expectedWeights {
-		achievedWeight, ok := achievedWeights[release]
-		if !ok {
-			f.Errorf("expected to find release %q in achievedWeights, but it wasn't there", release)
-			keepTesting = false
-			continue
-		}
-		if expectedWeight != achievedWeight {
-			f.Errorf("release %q expected weight %d but got %d", release, expectedWeight, achievedWeight)
-			keepTesting = false
-		}
-		delete(achievedWeights, release)
-	}
-
-	// Should be empty now.
-	for release, achievedWeight := range achievedWeights {
-		f.Errorf("release %q was found in achievedWeights with weight %d, but that map should be empty", release, achievedWeight)
-		keepTesting = false
-	}
-	return keepTesting
-}
-
-func (f *podLabelShifterFixture) checkReleasePodsWithTraffic(release string, expectedCount int) {
-	releaseTrafficSelector := labels.Merge(
-		f.svc.Spec.Selector,
-		map[string]string{
-			shipper.AppLabel:     testApplicationName,
-			shipper.ReleaseLabel: release,
-		},
-	).AsSelector()
-
-	pods, err := f.informers.Core().V1().Pods().Lister().Pods(shippertesting.TestNamespace).List(releaseTrafficSelector)
+	err := shiftPodLabels(clientset, podsToShift)
 	if err != nil {
-		panic(fmt.Sprintf(`Couldn't list pods: %s`, err))
+		t.Fatalf("unable to shift pod labels: %s", err)
 	}
 
-	trafficCount := len(pods)
-	if trafficCount != expectedCount {
-		f.Errorf("expected %d pods with traffic (using selector %v), but got %d", expectedCount, releaseTrafficSelector, trafficCount)
+	for newLabelValue, pods := range podsToShift {
+		for _, p := range pods {
+			gvr := corev1.SchemeGroupVersion.WithResource("pods")
+			obj, err := tracker.Get(gvr, shippertesting.TestNamespace, p.Name)
+			if err != nil {
+				panic(fmt.Sprintf("can't find pod %q: %s", p.Name, err))
+			}
+
+			pod := obj.(*corev1.Pod)
+
+			expectedLabels := p.Labels
+			p.Labels[shipper.PodTrafficStatusLabel] = newLabelValue
+
+			actualLabels := pod.Labels
+			eq, diff := shippertesting.DeepEqualDiff(expectedLabels, actualLabels)
+			if !eq {
+				t.Errorf("labels for pod %q differ from expected:\n%s", pod.Name, diff)
+			}
+		}
 	}
 }
 
-func newTrafficTarget(release string, clusterWeights map[string]uint32) *shipper.TrafficTarget {
-	tt := &shipper.TrafficTarget{
+func pod(name string, labels map[string]string) *corev1.Pod {
+	// NOTE: apiserver's implementation of json patch differs from the one
+	// in client-go's test reactor, so we have to cheat a little bit by
+	// pretending that we're always doing a "replace" instead of an "add".
+	// otherwise, it'll always complain with 'jsonpatch add operation does
+	// not apply: doc is missing path:
+	// "/metadata/labels/shipper-traffic-status"'
+	if _, ok := labels[shipper.PodTrafficStatusLabel]; !ok {
+		labels[shipper.PodTrafficStatusLabel] = ""
+	}
+
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			// NOTE(btyler): using release name for TTs?
-			Name:      release,
 			Namespace: shippertesting.TestNamespace,
-			Labels:    releaseLabels(release),
-		},
-		Spec: shipper.TrafficTargetSpec{
-			Clusters: []shipper.ClusterTrafficTarget{},
+			Name:      name,
+			Labels:    labels,
 		},
 	}
-
-	for cluster, weight := range clusterWeights {
-		tt.Spec.Clusters = append(tt.Spec.Clusters, shipper.ClusterTrafficTarget{
-			Name:   cluster,
-			Weight: weight,
-		})
-	}
-	return tt
-}
-
-func newReleasePods(release string, count int) []*corev1.Pod {
-	pods := make([]*corev1.Pod, 0, count)
-	for i := 0; i < count; i++ {
-		pods = append(pods, &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%d", release, i),
-				Namespace: shippertesting.TestNamespace,
-				Labels:    releaseLabels(release),
-			},
-		})
-	}
-	return pods
-}
-
-func releaseLabels(releaseName string) map[string]string {
-	labels := map[string]string{
-		shipper.AppLabel:     testApplicationName,
-		shipper.ReleaseLabel: releaseName,
-	}
-	return labels
 }

--- a/pkg/controller/traffic/traffic_shifting_status.go
+++ b/pkg/controller/traffic/traffic_shifting_status.go
@@ -1,81 +1,183 @@
 package traffic
 
 import (
+	"math"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shippererrors "github.com/bookingcom/shipper/pkg/errors"
+	"github.com/bookingcom/shipper/pkg/util/replicas"
 )
 
-type TrafficShiftingStatus struct {
-	LabeledPods   []*corev1.Pod
-	UnlabeledPods []*corev1.Pod
+type clusterReleaseWeights map[string]map[string]uint32
 
-	ReadyPods    int
-	NotReadyPods int
-
-	ReleasePods int
-
-	AchievedPercentage float64
-
-	podMap          map[string]*corev1.Pod
-	podReadinessMap map[string]bool
+type trafficShiftingStatus struct {
+	ready                 bool
+	achievedTrafficWeight uint32
+	podsReady             int
+	podsLabeled           int
+	podsToShift           map[string][]*corev1.Pod
 }
 
-func NewTrafficShiftingStatus(
-	pods []*corev1.Pod,
+// buildTrafficShiftingStatus looks at the current state of a cluster regarding
+// the progression of traffic shifting. It's concerned with how many of the
+// available pods have been labeled to receive traffic, how many are actually
+// ready according to the state of the Endpoints object, and the currently
+// achieved weight for a release. If the current state is different from the
+// desired one, it also returns which pods need to receive which labels to move
+// forward.
+func buildTrafficShiftingStatus(
+	cluster, appName, releaseName string,
+	clusterReleaseWeights clusterReleaseWeights,
 	endpoints *corev1.Endpoints,
-	trafficSelector labels.Selector,
-	releaseSelector labels.Selector,
-) *TrafficShiftingStatus {
-	status := &TrafficShiftingStatus{
-		podMap:          make(map[string]*corev1.Pod),
-		podReadinessMap: make(map[string]bool),
+	appPods []*corev1.Pod,
+) trafficShiftingStatus {
+	releaseTargetWeights, ok := clusterReleaseWeights[cluster]
+	if !ok {
+		return trafficShiftingStatus{}
 	}
 
+	releaseSelector := labels.Set(map[string]string{
+		shipper.AppLabel:     appName,
+		shipper.ReleaseLabel: releaseName,
+	}).AsSelector()
+
+	podsByTrafficStatus, podsInRelease, podsReady := summarizePods(
+		appPods, endpoints, releaseSelector)
+
+	releaseTargetWeight := releaseTargetWeights[releaseName]
+	totalTargetWeight := uint32(0)
+	for _, weight := range releaseTargetWeights {
+		totalTargetWeight += weight
+	}
+
+	podsInApp := len(appPods)
+	podsLabeledForTraffic := len(podsByTrafficStatus[shipper.Enabled])
+	podsToLabel := calculateReleasePodTarget(
+		podsInRelease, releaseTargetWeight, podsInApp, totalTargetWeight)
+
+	// A TrafficTarget is ready when it has achieved a certain number of
+	// pods, not a certain weight. That's because its number of pods is
+	// capped by the amount of pods in the release, which may be less than
+	// what the weight would require.
+	ready := podsReady == podsToLabel
+
+	var podsToShift map[string][]*corev1.Pod
+	if !ready {
+		podsToShift = buildPodsToShift(podsByTrafficStatus, podsToLabel)
+	}
+
+	var achievedPercentage float64
+	if podsInApp == 0 {
+		achievedPercentage = 0
+	} else {
+		achievedPercentage = float64(podsReady) / float64(podsInApp)
+	}
+	achievedWeight := uint32(math.Round(achievedPercentage * float64(totalTargetWeight)))
+
+	return trafficShiftingStatus{
+		achievedTrafficWeight: achievedWeight,
+		podsReady:             podsReady,
+		podsLabeled:           podsLabeledForTraffic,
+		ready:                 ready,
+		podsToShift:           podsToShift,
+	}
+}
+
+// buildPodsToShift returns a map of which label has to applied to which pods
+// so we have the correct amount of pods labeled to receive traffic.
+func buildPodsToShift(
+	podsByTrafficStatus map[string][]*corev1.Pod,
+	podsToLabel int,
+) map[string][]*corev1.Pod {
+	var oldStatus, newStatus string
+	var podsToTake int
+
+	podsLabeledForTraffic := len(podsByTrafficStatus[shipper.Enabled])
+	if podsLabeledForTraffic > podsToLabel {
+		// If we have more pods labeled for traffic than we
+		// need, we'll change some pods with
+		// PodTrafficStatusLabel=Enabled to Disabled...
+		podsToTake = podsLabeledForTraffic - podsToLabel
+		oldStatus = shipper.Enabled
+		newStatus = shipper.Disabled
+	} else {
+		// ... or some pods with PodTrafficStatusLabel=Disabled
+		// to Enabled otherwise.
+		podsToTake = podsToLabel - podsLabeledForTraffic
+		oldStatus = shipper.Disabled
+		newStatus = shipper.Enabled
+	}
+
+	if podsToTake > len(podsByTrafficStatus[oldStatus]) {
+		podsToTake = len(podsByTrafficStatus[oldStatus])
+	}
+
+	if podsToTake > 0 {
+		return map[string][]*corev1.Pod{
+			newStatus: podsByTrafficStatus[oldStatus][:podsToTake],
+		}
+	}
+
+	return nil
+}
+
+// summarizePods returns an aggregated summary of the current state of pods:
+// which pods are labeled to receive (or not receive) traffic, how many belong
+// to the specified release, and how many are ready according to the Endpoints
+// object.
+func summarizePods(
+	pods []*corev1.Pod,
+	endpoints *corev1.Endpoints,
+	releaseSelector labels.Selector,
+) (map[string][]*corev1.Pod, int, int) {
+	podsInRelease := make(map[string]struct{})
+	podsByTrafficStatus := make(map[string][]*corev1.Pod)
+
 	for _, pod := range pods {
-		podLabels := labels.Set(pod.Labels)
-		if !releaseSelector.Matches(podLabels) {
+		if !releaseSelector.Matches(labels.Set(pod.Labels)) {
 			continue
 		}
 
-		status.podMap[pod.Name] = pod
+		podsInRelease[pod.Name] = struct{}{}
 
-		status.ReleasePods++
-
-		if trafficSelector.Matches(podLabels) {
-			status.LabeledPods = append(status.LabeledPods, pod)
-		} else {
-			status.UnlabeledPods = append(status.UnlabeledPods, pod)
+		v, ok := pod.Labels[shipper.PodTrafficStatusLabel]
+		if !ok {
+			v = shipper.Disabled
 		}
+
+		podsByTrafficStatus[v] = append(podsByTrafficStatus[v], pod)
 	}
 
+	podReadiness := make(map[string]bool)
 	for _, subset := range endpoints.Subsets {
-		status.markAddressReadiness(subset.Addresses, true)
-		status.markAddressReadiness(subset.NotReadyAddresses, false)
+		markAddressReadiness(podReadiness, subset.Addresses, true)
+		markAddressReadiness(podReadiness, subset.NotReadyAddresses, false)
 	}
 
-	for podName, podReady := range status.podReadinessMap {
-		_, belongsToRelease := status.podMap[podName]
+	podsReady := 0
+	for podName, podReady := range podReadiness {
+		_, belongsToRelease := podsInRelease[podName]
 
 		if !belongsToRelease {
 			continue
 		}
 
 		if podReady {
-			status.ReadyPods++
-		} else {
-			status.NotReadyPods++
+			podsReady++
 		}
 	}
 
-	status.AchievedPercentage = float64(status.ReadyPods) / float64(len(status.podReadinessMap))
-
-	return status
+	return podsByTrafficStatus, len(podsInRelease), podsReady
 }
 
-// markAddressReadiness updates its internal map of pod readiness, by marking
+// markAddressReadiness updates podReadiness  by marking
 // the pods from a list of EndpointAddress as either ready or not ready
 // according to the markAs parameter.
-func (s *TrafficShiftingStatus) markAddressReadiness(
+func markAddressReadiness(
+	podReadiness map[string]bool,
 	addresses []corev1.EndpointAddress,
 	markAs bool,
 ) {
@@ -87,6 +189,72 @@ func (s *TrafficShiftingStatus) markAddressReadiness(
 			continue
 		}
 
-		s.podReadinessMap[target.Name] = markAs
+		podReadiness[target.Name] = markAs
 	}
+}
+
+/*
+	Transform this (a list of each release's traffic target object in this namespace):
+	[
+		{ tt-reviewsapi-1: { cluster-1: 90 } },
+		{ tt-reviewsapi-2: { cluster-1: 5 } },
+		{ tt-reviewsapi-3: { cluster-1: 5 } },
+	]
+
+	Into this (a map of release weight per cluster):
+	{
+		cluster-1: {
+			reviewsapi-1: 90,
+			reviewsapi-2: 5,
+			reviewsapi-3: 5,
+		}
+	}
+*/
+func buildClusterReleaseWeights(trafficTargets []*shipper.TrafficTarget) (clusterReleaseWeights, error) {
+	clusterReleases := map[string]map[string]uint32{}
+	releaseTT := map[string]*shipper.TrafficTarget{}
+
+	for _, tt := range trafficTargets {
+		release, ok := tt.Labels[shipper.ReleaseLabel]
+		if !ok {
+			err := shippererrors.NewMissingShipperLabelError(tt, shipper.ReleaseLabel)
+			return nil, err
+		}
+
+		existingTT, ok := releaseTT[release]
+		if ok {
+			return nil, shippererrors.NewMultipleTrafficTargetsForReleaseError(
+				tt.Namespace, release, []string{tt.Name, existingTT.Name})
+		}
+		releaseTT[release] = tt
+
+		for _, cluster := range tt.Spec.Clusters {
+			weights, ok := clusterReleases[cluster.Name]
+			if !ok {
+				weights = map[string]uint32{}
+				clusterReleases[cluster.Name] = weights
+			}
+			weights[release] += cluster.Weight
+		}
+	}
+
+	return clusterReleaseWeights(clusterReleases), nil
+}
+
+func calculateReleasePodTarget(releasePods int, releaseWeight uint32, totalPods int, totalWeight uint32) int {
+	// What percentage of the entire fleet (across all releases) should
+	// this set of pods represent.
+	var targetPercent float64
+	if totalWeight == 0 {
+		targetPercent = 0
+	} else {
+		targetPercent = float64(releaseWeight) / float64(totalWeight) * 100
+	}
+
+	// Round up to the nearest pod, clamped to the number of pods this
+	// release has.
+	targetPods := int(replicas.CalculateDesiredReplicaCount(uint(totalPods), float64(targetPercent)))
+	targetPods = int(math.Min(float64(releasePods), float64(targetPods)))
+
+	return targetPods
 }

--- a/pkg/controller/traffic/traffic_shifting_status_test.go
+++ b/pkg/controller/traffic/traffic_shifting_status_test.go
@@ -1,0 +1,363 @@
+package traffic
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+)
+
+type release struct {
+	weight   uint32
+	podCount podStatus
+}
+
+type podsToShift struct {
+	Enabled  int
+	Disabled int
+}
+
+type trafficShiftingStatusTestExpectation struct {
+	Release               release
+	Ready                 bool
+	AchievedTrafficWeight uint32
+	PodsReady             int
+	PodsLabeled           int
+	PodsToShift           podsToShift
+}
+
+func TestTrafficShiftingEmptyRelease(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release: release{weight: 0, podCount: podStatus{}},
+			Ready:   true,
+		},
+	})
+}
+
+func TestTrafficShiftingNoWeightRelease(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release: release{weight: 0, podCount: podStatus{withoutTraffic: 1}},
+			Ready:   true,
+		},
+	})
+}
+
+func TestTrafficShiftingNewRelease(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:     release{weight: 1, podCount: podStatus{withoutTraffic: 10}},
+			Ready:       false,
+			PodsToShift: podsToShift{10, 0},
+		},
+	})
+}
+
+func TestTrafficShiftingCompletedRelease(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 1, podCount: podStatus{withTraffic: 10}},
+			Ready:                 true,
+			AchievedTrafficWeight: 1,
+			PodsReady:             10,
+			PodsLabeled:           10,
+		},
+	})
+}
+
+func TestTrafficShiftingReleaseProgressionUp(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 1, podCount: podStatus{withTraffic: 5, withoutTraffic: 5}},
+			Ready:                 false,
+			AchievedTrafficWeight: 1,
+			PodsReady:             5,
+			PodsLabeled:           5,
+			PodsToShift:           podsToShift{5, 0},
+		},
+	})
+}
+
+func TestTrafficShiftingReleaseProgressionDown(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 0, podCount: podStatus{withTraffic: 5}},
+			Ready:                 false,
+			AchievedTrafficWeight: 0,
+			PodsReady:             5,
+			PodsLabeled:           5,
+			PodsToShift:           podsToShift{0, 5},
+		},
+	})
+}
+
+func TestTrafficShiftingReleaseProgressionDrainIncumbentReplenishContender(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 0, podCount: podStatus{withTraffic: 10}},
+			Ready:                 false,
+			AchievedTrafficWeight: 1,
+			PodsReady:             10,
+			PodsLabeled:           10,
+			PodsToShift:           podsToShift{0, 10},
+		},
+		{
+			Release:               release{weight: 1, podCount: podStatus{withoutTraffic: 10}},
+			Ready:                 false,
+			AchievedTrafficWeight: 0,
+			PodsToShift:           podsToShift{10, 0},
+		},
+	})
+}
+
+func TestTrafficShiftingReleaseSeveralAchievedReleases(t *testing.T) {
+	var expectations []trafficShiftingStatusTestExpectation
+	for i := 0; i < 5; i++ {
+		expectations = append(expectations, trafficShiftingStatusTestExpectation{
+			Release:               release{weight: 10, podCount: podStatus{withTraffic: 5}},
+			Ready:                 true,
+			AchievedTrafficWeight: 10,
+			PodsReady:             5,
+			PodsLabeled:           5,
+		})
+	}
+
+	runBuildTestTrafficShiftingStatus(t, expectations)
+}
+
+func TestTrafficShiftingReleaseSeveralReleasesDifferentWeights(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 10, podCount: podStatus{withTraffic: 10}},
+			Ready:                 false,
+			AchievedTrafficWeight: 15,
+			PodsReady:             10,
+			PodsLabeled:           10,
+			PodsToShift:           podsToShift{0, 3},
+		},
+		{
+			Release:               release{weight: 20, podCount: podStatus{withTraffic: 10}},
+			Ready:                 true,
+			AchievedTrafficWeight: 15,
+			PodsReady:             10,
+			PodsLabeled:           10,
+		},
+	})
+}
+
+func TestTrafficShiftingMassiveWeightDisparity(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 1, podCount: podStatus{withTraffic: 10}},
+			Ready:                 false,
+			AchievedTrafficWeight: 5001,
+			PodsReady:             10,
+			PodsLabeled:           10,
+			PodsToShift:           podsToShift{0, 9},
+		},
+		{
+			Release:               release{weight: 10000, podCount: podStatus{withTraffic: 10}},
+			Ready:                 true,
+			AchievedTrafficWeight: 5001,
+			PodsReady:             10,
+			PodsLabeled:           10,
+		},
+	})
+}
+
+func TestTrafficShiftingUnevedPodsEqualWeights(t *testing.T) {
+	runBuildTestTrafficShiftingStatus(t, []trafficShiftingStatusTestExpectation{
+		{
+			Release:               release{weight: 100, podCount: podStatus{withTraffic: 10}},
+			Ready:                 false,
+			AchievedTrafficWeight: 182,
+			PodsReady:             10,
+			PodsLabeled:           10,
+			PodsToShift:           podsToShift{0, 4},
+		},
+		{
+			Release:               release{weight: 100, podCount: podStatus{withTraffic: 1}},
+			Ready:                 true,
+			AchievedTrafficWeight: 18,
+			PodsReady:             1,
+			PodsLabeled:           1,
+		},
+	})
+}
+
+func TestTrafficShiftingPodsLabeledButNotReady(t *testing.T) {
+	releaseName := "foobar"
+	releaseWeight := uint32(10)
+
+	appPods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-ready",
+				Namespace: shippertesting.TestNamespace,
+				Labels: map[string]string{
+					shipper.AppLabel:              shippertesting.TestApp,
+					shipper.ReleaseLabel:          releaseName,
+					shipper.PodTrafficStatusLabel: shipper.Enabled,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-not-ready",
+				Namespace: shippertesting.TestNamespace,
+				Labels: map[string]string{
+					shipper.AppLabel:              shippertesting.TestApp,
+					shipper.ReleaseLabel:          releaseName,
+					shipper.PodTrafficStatusLabel: shipper.Enabled,
+					podReadinessLabel:             podNotReady,
+				},
+			},
+		},
+	}
+
+	endpoints := buildEndpoints(shippertesting.TestApp)
+	for _, pod := range appPods {
+		endpoints = shiftPodInEndpoints(pod, endpoints)
+	}
+
+	trafficStatus := buildTrafficShiftingStatus(
+		shippertesting.TestCluster, shippertesting.TestApp, releaseName,
+		clusterReleaseWeights{
+			shippertesting.TestCluster: map[string]uint32{
+				releaseName: releaseWeight,
+			},
+		},
+		endpoints, appPods,
+	)
+
+	assertTrafficShiftingStatusExpectation(t, releaseName,
+		trafficShiftingStatusTestExpectation{
+			Release:               release{weight: releaseWeight},
+			Ready:                 false,
+			AchievedTrafficWeight: 5,
+			PodsLabeled:           2,
+			PodsReady:             1,
+		}, trafficStatus)
+}
+
+func TestTrafficShiftingUnmanagedPods(t *testing.T) {
+	releaseName := "foobar"
+	releaseWeight := uint32(10)
+
+	appPods := buildPods(shippertesting.TestApp, releaseName, 5, noTraffic)
+
+	appPods = append(appPods, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unmanaged-pod",
+			Namespace: shippertesting.TestNamespace,
+			Labels: map[string]string{
+				shipper.AppLabel:     "bar",
+				shipper.ReleaseLabel: "baz",
+			},
+		},
+	})
+
+	endpoints := buildEndpoints(shippertesting.TestApp)
+	trafficStatus := buildTrafficShiftingStatus(
+		shippertesting.TestCluster, shippertesting.TestApp, releaseName,
+		clusterReleaseWeights{
+			shippertesting.TestCluster: map[string]uint32{
+				releaseName: releaseWeight,
+			},
+		},
+		endpoints, appPods,
+	)
+
+	assertTrafficShiftingStatusExpectation(t, releaseName,
+		trafficShiftingStatusTestExpectation{
+			Release:     release{weight: releaseWeight},
+			Ready:       false,
+			PodsToShift: podsToShift{5, 0},
+		}, trafficStatus)
+}
+
+func runBuildTestTrafficShiftingStatus(
+	t *testing.T,
+	expectations []trafficShiftingStatusTestExpectation,
+) {
+	var appPods []*corev1.Pod
+	endpoints := buildEndpoints(shippertesting.TestApp)
+	trafficTargets := make([]*shipper.TrafficTarget, 0, len(expectations))
+	for i, expectation := range expectations {
+		release := expectation.Release
+		releaseName := fmt.Sprintf("release-%d", i)
+
+		trafficTargets = append(trafficTargets, buildTrafficTarget(
+			shippertesting.TestApp, releaseName, map[string]uint32{
+				shippertesting.TestCluster: release.weight,
+			},
+		))
+
+		podsWithTraffic := buildPods(
+			shippertesting.TestApp,
+			releaseName,
+			release.podCount.withTraffic,
+			withTraffic)
+
+		podsWithoutTraffic := buildPods(
+			shippertesting.TestApp,
+			releaseName,
+			release.podCount.withoutTraffic,
+			noTraffic)
+
+		for _, pod := range podsWithTraffic {
+			endpoints = shiftPodInEndpoints(pod, endpoints)
+		}
+
+		appPods = append(appPods, podsWithTraffic...)
+		appPods = append(appPods, podsWithoutTraffic...)
+	}
+
+	clusterReleaseWeights, err := buildClusterReleaseWeights(trafficTargets)
+	if err != nil {
+		t.Fatalf("cannot build cluster release weights: %s", err)
+	}
+
+	for i, expectation := range expectations {
+		tt := trafficTargets[i]
+		relName := tt.Labels[shipper.ReleaseLabel]
+		trafficStatus := buildTrafficShiftingStatus(
+			shippertesting.TestCluster, shippertesting.TestApp, relName,
+			clusterReleaseWeights,
+			endpoints, appPods,
+		)
+
+		assertTrafficShiftingStatusExpectation(t, relName, expectation, trafficStatus)
+	}
+}
+
+func assertTrafficShiftingStatusExpectation(
+	t *testing.T,
+	relName string,
+	expectation trafficShiftingStatusTestExpectation,
+	trafficStatus trafficShiftingStatus,
+) {
+	actual := trafficShiftingStatusTestExpectation{
+		Release:               expectation.Release,
+		Ready:                 trafficStatus.ready,
+		AchievedTrafficWeight: trafficStatus.achievedTrafficWeight,
+		PodsReady:             trafficStatus.podsReady,
+		PodsLabeled:           trafficStatus.podsLabeled,
+		PodsToShift: podsToShift{
+			Enabled:  len(trafficStatus.podsToShift[shipper.Enabled]),
+			Disabled: len(trafficStatus.podsToShift[shipper.Disabled]),
+		},
+	}
+
+	eq, diff := shippertesting.DeepEqualDiff(expectation, actual)
+	if !eq {
+		t.Errorf(
+			"release %q got a different traffic shifting status than expected:\n%s",
+			relName, diff)
+	}
+}

--- a/pkg/controller/traffic/utils_test.go
+++ b/pkg/controller/traffic/utils_test.go
@@ -2,18 +2,55 @@ package traffic
 
 import (
 	"fmt"
+	"sort"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 )
 
-// NOTE: this does not try to implement endpoint subsets at all. All
-// pods are assumed to be part of the same subset and to be always ready.
+const (
+	podReadinessLabel = "shipper-test-pod-ready"
+	podReady          = "true"
+	podNotReady       = "false"
+
+	withTraffic = true
+	noTraffic   = false
+)
+
+type podStatus struct {
+	withTraffic    int
+	withoutTraffic int
+}
+
+var (
+	TargetConditionOperational = shipper.TargetCondition{
+		Type:   shipper.TargetConditionTypeOperational,
+		Status: corev1.ConditionTrue,
+	}
+	TargetConditionReady = shipper.TargetCondition{
+		Type:   shipper.TargetConditionTypeReady,
+		Status: corev1.ConditionTrue,
+	}
+	ClusterTrafficOperational = shipper.ClusterTrafficCondition{
+		Type:   shipper.ClusterConditionTypeOperational,
+		Status: corev1.ConditionTrue,
+	}
+	ClusterTrafficReady = shipper.ClusterTrafficCondition{
+		Type:   shipper.ClusterConditionTypeReady,
+		Status: corev1.ConditionTrue,
+	}
+)
+
+// NOTE: this does not try to implement endpoint subsets at all. All pods are
+// assumed to be part of the same subset, and it checks magic labels to decide
+// if they're ready.
 func shiftPodInEndpoints(pod *corev1.Pod, endpoints *corev1.Endpoints) *corev1.Endpoints {
 	var podGetsTraffic bool
 	trafficStatusLabel, ok := pod.Labels[shipper.PodTrafficStatusLabel]
@@ -21,7 +58,21 @@ func shiftPodInEndpoints(pod *corev1.Pod, endpoints *corev1.Endpoints) *corev1.E
 		podGetsTraffic = trafficStatusLabel == shipper.Enabled
 	}
 
-	addresses := endpoints.Subsets[0].Addresses
+	endpoints = endpoints.DeepCopy()
+
+	var addresses []corev1.EndpointAddress
+	ready := true
+	readyLabel, ok := pod.Labels[podReadinessLabel]
+	if ok {
+		ready = readyLabel == podReady
+	}
+
+	if ready {
+		addresses = endpoints.Subsets[0].Addresses
+	} else {
+		addresses = endpoints.Subsets[0].NotReadyAddresses
+	}
+
 	addressIndex := -1
 	for i, address := range addresses {
 		if address.TargetRef.Name == pod.Name {
@@ -31,24 +82,158 @@ func shiftPodInEndpoints(pod *corev1.Pod, endpoints *corev1.Endpoints) *corev1.E
 	}
 
 	if podGetsTraffic && addressIndex == -1 {
-		address := corev1.EndpointAddress{
+		addresses = append(addresses, corev1.EndpointAddress{
 			TargetRef: &corev1.ObjectReference{
 				Kind:      "Pod",
 				Namespace: pod.Namespace,
 				Name:      pod.Name,
 			},
-		}
-
-		endpoints.Subsets[0] = corev1.EndpointSubset{
-			Addresses: append(addresses, address),
-		}
+		})
 	} else if !podGetsTraffic && addressIndex >= 0 {
-		endpoints.Subsets[0] = corev1.EndpointSubset{
-			Addresses: append(addresses[:addressIndex], addresses[:addressIndex+1]...),
-		}
+		addresses = append(addresses[:addressIndex], addresses[:addressIndex+1]...)
+	}
+
+	if ready {
+		endpoints.Subsets[0].Addresses = addresses
+	} else {
+		endpoints.Subsets[0].NotReadyAddresses = addresses
 	}
 
 	return endpoints
+}
+
+func buildTrafficTarget(app, release string, clusterWeights map[string]uint32) *shipper.TrafficTarget {
+	clusters := make([]shipper.ClusterTrafficTarget, 0, len(clusterWeights))
+
+	for cluster, weight := range clusterWeights {
+		clusters = append(clusters, shipper.ClusterTrafficTarget{
+			Name:   cluster,
+			Weight: weight,
+		})
+	}
+
+	return &shipper.TrafficTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      release,
+			Namespace: shippertesting.TestNamespace,
+			Labels: map[string]string{
+				shipper.AppLabel:     app,
+				shipper.ReleaseLabel: release,
+			},
+		},
+		Spec: shipper.TrafficTargetSpec{
+			Clusters: clusters,
+		},
+	}
+}
+
+func buildSuccessStatus(clusters []shipper.ClusterTrafficTarget) shipper.TrafficTargetStatus {
+	clusterStatuses := make([]*shipper.ClusterTrafficStatus, 0, len(clusters))
+
+	for _, cluster := range clusters {
+		clusterStatuses = append(clusterStatuses, &shipper.ClusterTrafficStatus{
+			Name:            cluster.Name,
+			AchievedTraffic: cluster.Weight,
+			Conditions: []shipper.ClusterTrafficCondition{
+				ClusterTrafficOperational,
+				ClusterTrafficReady,
+			},
+		})
+	}
+
+	sort.Sort(byClusterName(clusterStatuses))
+
+	return shipper.TrafficTargetStatus{
+		Clusters: clusterStatuses,
+		Conditions: []shipper.TargetCondition{
+			TargetConditionOperational,
+			TargetConditionReady,
+		},
+	}
+}
+
+func buildService(app string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-prod", app),
+			Namespace: shippertesting.TestNamespace,
+			Labels: map[string]string{
+				shipper.LBLabel:  shipper.LBForProduction,
+				shipper.AppLabel: app,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				shipper.AppLabel:              app,
+				shipper.PodTrafficStatusLabel: shipper.Enabled,
+			},
+		},
+	}
+}
+
+func buildEndpoints(app string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-prod", app),
+			Namespace: shippertesting.TestNamespace,
+			Labels: map[string]string{
+				shipper.LBLabel:  shipper.LBForProduction,
+				shipper.AppLabel: app,
+			},
+		},
+		Subsets: []corev1.EndpointSubset{
+			corev1.EndpointSubset{
+				Addresses: []corev1.EndpointAddress{},
+			},
+		},
+	}
+}
+
+var podId int
+
+func buildPods(app, release string, count int, withTraffic bool) []*corev1.Pod {
+	pods := make([]*corev1.Pod, 0, count)
+
+	for i := 0; i < count; i++ {
+		getsTraffic := shipper.Enabled
+		if !withTraffic {
+			getsTraffic = shipper.Disabled
+		}
+
+		podId += 1
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", release, podId),
+				Namespace: shippertesting.TestNamespace,
+				Labels: map[string]string{
+					shipper.AppLabel:              app,
+					shipper.ReleaseLabel:          release,
+					shipper.PodTrafficStatusLabel: getsTraffic,
+				},
+			},
+		})
+	}
+
+	return pods
+}
+
+func buildWorldWithPods(app, release string, n int, traffic bool) []runtime.Object {
+	objects := []runtime.Object{
+		buildService(app),
+		buildEndpoints(app),
+	}
+
+	objects = addPodsToList(objects, buildPods(app, release, n, traffic))
+
+	return objects
+}
+
+func addPodsToList(objects []runtime.Object, pods []*corev1.Pod) []runtime.Object {
+	for _, pod := range pods {
+		objects = append(objects, pod)
+	}
+
+	return objects
 }
 
 type ControllerTestFixture struct {

--- a/pkg/errors/traffic.go
+++ b/pkg/errors/traffic.go
@@ -28,51 +28,6 @@ func NewMissingShipperLabelError(tt *shipper.TrafficTarget, label string) Missin
 	}
 }
 
-type MissingTrafficWeightsForClusterError struct {
-	ns          string
-	appName     string
-	clusterName string
-}
-
-func (e MissingTrafficWeightsForClusterError) Error() string {
-	return fmt.Sprintf(`Application "%s/%s" has no traffic weights for cluster %s`,
-		e.ns, e.appName, e.clusterName)
-}
-
-func (e MissingTrafficWeightsForClusterError) ShouldRetry() bool {
-	return false
-}
-
-func NewMissingTrafficWeightsForClusterError(ns, appName, clusterName string) MissingTrafficWeightsForClusterError {
-	return MissingTrafficWeightsForClusterError{
-		ns:          ns,
-		appName:     appName,
-		clusterName: clusterName,
-	}
-}
-
-type MissingTargetClusterSelectorError struct {
-	ns          string
-	serviceName string
-}
-
-func (e MissingTargetClusterSelectorError) ShouldRetry() bool {
-	return true
-}
-
-func (e MissingTargetClusterSelectorError) Error() string {
-	return fmt.Sprintf(
-		"service %s/%s does not have a selector set. this means we cannot do label-based canary deployment",
-		e.ns, e.serviceName)
-}
-
-func NewTargetClusterServiceMissesSelectorError(ns, serviceName string) MissingTargetClusterSelectorError {
-	return MissingTargetClusterSelectorError{
-		ns:          ns,
-		serviceName: serviceName,
-	}
-}
-
 type MultipleTrafficTargetsForReleaseError struct {
 	ns          string
 	releaseName string
@@ -94,24 +49,4 @@ func NewMultipleTrafficTargetsForReleaseError(ns, releaseName string, ttNames []
 		releaseName: releaseName,
 		ttNames:     ttNames,
 	}
-}
-
-type TargetClusterMathError struct {
-	releaseName  string
-	idlePodCount int
-	missingCount int
-}
-
-func NewTargetClusterMathError(releaseName string, idlePodCount, missingCount int) TargetClusterMathError {
-	return TargetClusterMathError{
-		releaseName:  releaseName,
-		idlePodCount: idlePodCount,
-		missingCount: missingCount,
-	}
-}
-
-func (e TargetClusterMathError) Error() string {
-	return fmt.Sprintf(
-		"release error (%q): the math is broken: there aren't enough idle pods (%d) to meet requested increase in traffic pods (%d)",
-		e.releaseName, e.idlePodCount, e.missingCount)
 }

--- a/pkg/testing/util.go
+++ b/pkg/testing/util.go
@@ -20,9 +20,11 @@ const (
 	ContextLines = 4
 
 	TestNamespace = "test-namespace"
-	TestLabel     = "shipper-e2e-test"
+	TestApp       = "shipper-test"
+	TestRegion    = "eu-west"
+	TestCluster   = "test-cluster"
 
-	TestRegion = "eu-west"
+	E2ETestNamespaceLabel = "shipper-e2e-test"
 )
 
 // CheckActions takes a slice of expected actions and a slice of observed
@@ -182,7 +184,7 @@ func YamlDiff(a interface{}, b interface{}) (string, error) {
 		B:        difflib.SplitLines(string(yamlActual)),
 		FromFile: "Expected",
 		ToFile:   "Actual",
-		Context:  4,
+		Context:  ContextLines,
 	}
 
 	return difflib.GetUnifiedDiffString(diff)

--- a/test/e2e/e2e_util.go
+++ b/test/e2e/e2e_util.go
@@ -296,7 +296,7 @@ func teardownNamespace(name string) {
 
 func purgeTestNamespaces() {
 	req, err := labels.NewRequirement(
-		shippertesting.TestLabel,
+		shippertesting.E2ETestNamespaceLabel,
 		selection.Exists,
 		[]string{},
 	)
@@ -352,7 +352,7 @@ func testNamespace(name string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				shippertesting.TestLabel: name,
+				shippertesting.E2ETestNamespaceLabel: name,
 			},
 		},
 	}


### PR DESCRIPTION
This builds on top of work done in #241 , which builds on top of #238, so make sure those are merged before going through the changes here :)

Before this, the pod label shifter would return a bogus achieved traffic
weight whenever the number of pods required to take traffic was equal to
the number of pods ready. Fixing that up front would've broken the
release controller, as it used to check the achieved traffic weight
instead of just looking at conditions (which at the time didn't exist).
Now that this has been fixed [1], we can start reporting the actual
achieved weight instead of having to lie.

The diff is also a fair bit larger than it should be, since I got a bit
carried away with the pod label shifter refactoring. There's a
rationale, though: it moves all the actual logic of traffic calculations
away from ever touching informers and clients and into
traffic_shifting_status.go, making unit testing much easier.
pod_label_shifter.go now only does the mechanical job of shifting
labels, making its own surface area much smaller. As a bonus, tests are
much faster too!

Last but not least, now we can also tell the difference traffic shifting
being in progress (as in, shipper is currently moving labels around) and
it being stuck (as in, pods aren't ready). This was also some extra
motivation for the state we accumulate in trafficShiftingStatus.

[1] https://github.com/bookingcom/shipper/pull/241