### PR TITLE
Namespace Secret informer to only shipper-system

### DIFF
--- a/pkg/clusterclientstore/queue.go
+++ b/pkg/clusterclientstore/queue.go
@@ -34,7 +34,7 @@ func (s *Store) bindEventHandlers() {
 			// This is a bit aggressive, but I think it makes sense; otherwise we get
 			// logs about the service account token.
 			_, ok = secret.GetAnnotations()[shipper.SecretChecksumAnnotation]
-			return ok && secret.Namespace == shipper.ShipperNamespace
+			return ok
 		},
 		Handler: kubecache.ResourceEventHandlerFuncs{
 			AddFunc: enqueueSecret,

--- a/pkg/clusterclientstore/store.go
+++ b/pkg/clusterclientstore/store.go
@@ -201,8 +201,8 @@ func (s *Store) syncSecret(key string) error {
 		return shippererrors.NewUnrecoverableError(err)
 	}
 
-	// Programmer error: there's a filter func on the callbacks before things get
-	// enqueued.
+	// Programmer error: secretInformer needs to be namespaced to only
+	// shipper's own namespace.
 	if ns != s.ns {
 		panic("client store secret workqueue should only contain secrets from the shipper namespace")
 	}


### PR DESCRIPTION
Right now our client store uses a Secrets informer generated from a
kubeInformerFactory configured to list things for the entire cluster.
This is more power than we need. Instead, that kubeInformerFactory
should be filtered to only look at the Shipper namespace.

Closes #52 