### PR TITLE
installer: validate manifests before attempting to install

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -301,7 +301,7 @@ func (c *Controller) processInstallationTarget(it *shipper.InstallationTarget) (
 	diff := diffutil.NewMultiDiff()
 	defer c.reportConditionChange(it, InstallationTargetConditionChanged, diff)
 
-	installer, err := NewInstaller(c.chartFetcher, it)
+	objects, err := FetchAndRenderChart(c.chartFetcher, it)
 	if err != nil {
 		it.Status.Conditions = targetutil.TransitionToNotOperational(
 			diff, it.Status.Conditions,
@@ -311,6 +311,7 @@ func (c *Controller) processInstallationTarget(it *shipper.InstallationTarget) (
 
 	it.Status.Conditions = targetutil.TransitionToOperational(diff, it.Status.Conditions)
 
+	installer := NewInstaller(it, objects)
 	newClusterStatuses := make([]*shipper.ClusterInstallationStatus, 0, len(it.Spec.Clusters))
 	clusterErrors := shippererrors.NewMultiError()
 

--- a/pkg/controller/installation/installation_controller_test.go
+++ b/pkg/controller/installation/installation_controller_test.go
@@ -89,36 +89,20 @@ func TestMultipleClusters(t *testing.T) {
 	)
 }
 
-// TestInstallationFailed verifies that the installation controller updates the
-// installation traffic with the correct conditions when a chart can't be
-// installed in a cluster.
-func TestInstallationFailed(t *testing.T) {
-	clusters := []string{clusterA}
+// TestInvalidChart verifies that the installation controller updates the
+// installation traffic with the correct conditions when a chart is invalid.
+func TestInvalidChart(t *testing.T) {
+	clusters := []string{}
 	chart := buildChart("reviews-api", "invalid-deployment-name", repoUrl)
 	it := buildInstallationTarget(shippertesting.TestNamespace, shippertesting.TestApp, clusters, &chart)
 
 	status := shipper.InstallationTargetStatus{
-		Clusters: []*shipper.ClusterInstallationStatus{
-			{
-				Name: clusterA,
-				Conditions: []shipper.ClusterInstallationCondition{
-					ClusterInstallationOperational,
-					{
-						Type:    shipper.ClusterConditionTypeReady,
-						Status:  corev1.ConditionFalse,
-						Reason:  ChartError,
-						Message: `Deployment "reviews-api" has invalid name. The name of the Deployment should be templated with {{.Release.Name}}.`,
-					},
-				},
-			},
-		},
 		Conditions: []shipper.TargetCondition{
-			TargetConditionOperational,
 			{
-				Type:    shipper.TargetConditionTypeReady,
+				Type:    shipper.TargetConditionTypeOperational,
 				Status:  corev1.ConditionFalse,
-				Reason:  ClustersNotReady,
-				Message: fmt.Sprintf("%v", []string{clusterA}),
+				Reason:  ChartError,
+				Message: `Deployment "reviews-api" has invalid name. The name of the Deployment should be templated with {{.Release.Name}}.`,
 			},
 		},
 	}

--- a/pkg/controller/installation/installer.go
+++ b/pkg/controller/installation/installer.go
@@ -4,173 +4,41 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	helmchart "k8s.io/helm/pkg/proto/hapi/chart"
-	"k8s.io/klog"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
-	shipperchart "github.com/bookingcom/shipper/pkg/chart"
-	shipperrepo "github.com/bookingcom/shipper/pkg/chart/repo"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
 	"github.com/bookingcom/shipper/pkg/util/anchor"
 )
 
 type DynamicClientBuilderFunc func(gvk *schema.GroupVersionKind, restConfig *rest.Config, cluster *shipper.Cluster) dynamic.Interface
 
-// Installer is an object that knows how to install Helm charts directly into
-// Kubernetes clusters.
+// Installer is an object that knows how to install objects into Kubernetes
+// clusters.
 type Installer struct {
 	installationTarget *shipper.InstallationTarget
-	preparedObjects    []runtime.Object
+	objects            []runtime.Object
 }
 
 // NewInstaller returns a new Installer.
 func NewInstaller(
-	chartFetcher shipperrepo.ChartFetcher,
 	it *shipper.InstallationTarget,
-) (*Installer, error) {
-	chart, err := chartFetcher(it.Spec.Chart)
-	if err != nil {
-		return nil, err
-	}
-
-	manifests, err := renderManifests(it, chart)
-	if err != nil {
-		return nil, err
-	}
-
-	preparedObjects, err := prepareObjects(it, manifests)
-	if err != nil {
-		return nil, err
-	}
-
+	objects []runtime.Object,
+) *Installer {
 	return &Installer{
 		installationTarget: it,
-		preparedObjects:    preparedObjects,
-	}, nil
-}
-
-// renderManifests returns a list of rendered manifests for a given
-// InstallationTarget and chart, or an error.
-func renderManifests(it *shipper.InstallationTarget, chart *helmchart.Chart) ([]string, error) {
-	rendered, err := shipperchart.Render(
-		chart,
-		it.GetName(),
-		it.GetNamespace(),
-		it.Spec.Values,
-	)
-
-	if err != nil {
-		return nil, shippererrors.NewRenderManifestError(err)
+		objects:            objects,
 	}
-
-	for _, v := range rendered {
-		klog.V(10).Infof("Rendered object:\n%s", v)
-	}
-
-	return rendered, nil
-}
-
-type kubeobj interface {
-	runtime.Object
-	GetLabels() map[string]string
-	SetLabels(map[string]string)
-}
-
-func prepareObjects(it *shipper.InstallationTarget, manifests []string) ([]runtime.Object, error) {
-	shipperLabels := labels.Merge(labels.Set(it.Labels), labels.Set{
-		shipper.InstallationTargetOwnerLabel: it.Name,
-	})
-
-	var (
-		allServices          []*corev1.Service
-		productionLBServices []*corev1.Service
-	)
-
-	preparedObjects := make([]runtime.Object, 0, len(manifests))
-	for _, manifest := range manifests {
-		decodedObj, _, err :=
-			kubescheme.Codecs.
-				UniversalDeserializer().
-				Decode([]byte(manifest), nil, nil)
-
-		if err != nil {
-			return nil, shippererrors.NewDecodeManifestError("error decoding manifest: %s", err)
-		}
-
-		switch obj := decodedObj.(type) {
-		case *appsv1.Deployment:
-			// We need the Deployment in the chart to have a unique
-			// name, meaning that different installations need to
-			// generate Deployments with different names,
-			// otherwise, we try to overwrite a previous
-			// Deployment, and that fails with a "field is
-			// immutable" error.
-			deploymentName := obj.Name
-			expectedName := it.Name
-			if !strings.Contains(deploymentName, expectedName) {
-				return nil, shippererrors.NewInvalidChartError(
-					fmt.Sprintf("Deployment %q has invalid name."+
-						" The name of the Deployment should be"+
-						" templated with {{.Release.Name}}.",
-						deploymentName),
-				)
-			}
-
-			decodedObj = patchDeployment(obj, shipperLabels)
-		case *corev1.Service:
-			allServices = append(allServices, obj)
-
-			lbValue, ok := obj.Labels[shipper.LBLabel]
-			if ok && lbValue == shipper.LBForProduction {
-				productionLBServices = append(productionLBServices, obj)
-			}
-		}
-
-		obj := decodedObj.(kubeobj)
-		obj.SetLabels(labels.Merge(
-			obj.GetLabels(),
-			shipperLabels,
-		))
-
-		preparedObjects = append(preparedObjects, obj)
-	}
-
-	// If we have observed only 1 Service object and it was not marked with
-	// shipper-lb=production label, we can do it ourselves.
-	if len(productionLBServices) == 0 && len(allServices) == 1 {
-		productionLBServices = allServices
-	}
-
-	// If, after all, we still can not identify a single Service which will
-	// be the production LB, there is nothing else to do rather than bail
-	// out
-	if len(productionLBServices) != 1 {
-		return nil, shippererrors.NewInvalidChartError(
-			fmt.Sprintf(
-				"one and only one v1.Service object with label %q is required, but %d found instead",
-				shipper.LBLabel, len(productionLBServices)))
-	}
-
-	err := patchService(it, productionLBServices[0])
-	if err != nil {
-		return nil, err
-	}
-
-	return preparedObjects, nil
 }
 
 // buildResourceClient returns a ResourceClient suitable to manipulate the kind
@@ -221,64 +89,6 @@ func (i *Installer) buildResourceClient(
 	}
 }
 
-func patchDeployment(d *appsv1.Deployment, labelsToInject map[string]string) runtime.Object {
-	replicas := int32(0)
-	d.Spec.Replicas = &replicas
-
-	var newSelector *metav1.LabelSelector
-	if d.Spec.Selector != nil {
-		newSelector = d.Spec.Selector.DeepCopy()
-	} else {
-		newSelector = &metav1.LabelSelector{
-			MatchLabels: map[string]string{},
-		}
-	}
-
-	for k, v := range labelsToInject {
-		newSelector.MatchLabels[k] = v
-	}
-	d.Spec.Selector = newSelector
-
-	podTemplateLabels := d.Spec.Template.Labels
-	for k, v := range labelsToInject {
-		podTemplateLabels[k] = v
-	}
-	d.Spec.Template.SetLabels(podTemplateLabels)
-
-	return d
-}
-
-func patchService(it *shipper.InstallationTarget, s *corev1.Service) error {
-	if relName, ok := s.Spec.Selector[shipper.HelmReleaseLabel]; ok {
-		v, ok := it.Labels[shipper.HelmWorkaroundLabel]
-		if ok && v == shipper.True {
-			// This selector label is native to helm-bootstrapped charts.
-			// In order to make it work the shipper way, we remove the
-			// label and proceed normally. With one little twist: the user
-			// has to ask shipper to do it explicitly.
-			if relName == it.Name {
-				delete(s.Spec.Selector, shipper.HelmReleaseLabel)
-			}
-		} else if !ok || v == shipper.False {
-			return shippererrors.NewInvalidChartError(
-				fmt.Sprintf("The chart contains %q label in Service object %q. This will"+
-					" break shipper traffic shifting logic. Consider adding the workaround"+
-					" label %q: true to your Application object",
-					shipper.HelmReleaseLabel, s.Name, shipper.HelmWorkaroundLabel))
-		} else {
-			return shippererrors.NewInvalidChartError(
-				fmt.Sprintf("Unexpected value for label %q: %q. Expected values: %s/%s.",
-					shipper.HelmWorkaroundLabel, v, shipper.True, shipper.False))
-		}
-	}
-
-	s.Labels[shipper.LBLabel] = shipper.LBForProduction
-	s.Spec.Selector[shipper.AppLabel] = s.Labels[shipper.AppLabel]
-	s.Spec.Selector[shipper.PodTrafficStatusLabel] = shipper.Enabled
-
-	return nil
-}
-
 // install attempts to install the manifests on the specified cluster.
 func (i *Installer) install(
 	cluster *shipper.Cluster,
@@ -308,7 +118,7 @@ func (i *Installer) install(
 
 	ownerReference := anchor.ConfigMapAnchorToOwnerReference(createdConfigMap)
 
-	for _, preparedObj := range i.preparedObjects {
+	for _, preparedObj := range i.objects {
 		obj := &unstructured.Unstructured{}
 		err = kubescheme.Scheme.Convert(preparedObj, obj, nil)
 		if err != nil {

--- a/pkg/controller/installation/renderer.go
+++ b/pkg/controller/installation/renderer.go
@@ -1,0 +1,187 @@
+package installation
+
+import (
+	"fmt"
+	"strings"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperchart "github.com/bookingcom/shipper/pkg/chart"
+	shipperrepo "github.com/bookingcom/shipper/pkg/chart/repo"
+	shippererrors "github.com/bookingcom/shipper/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+type kubeobj interface {
+	runtime.Object
+	GetLabels() map[string]string
+	SetLabels(map[string]string)
+}
+
+func FetchAndRenderChart(
+	chartFetcher shipperrepo.ChartFetcher,
+	it *shipper.InstallationTarget,
+) ([]runtime.Object, error) {
+	chart, err := chartFetcher(it.Spec.Chart)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := shipperchart.Render(
+		chart,
+		it.GetName(),
+		it.GetNamespace(),
+		it.Spec.Values,
+	)
+
+	if err != nil {
+		return nil, shippererrors.NewRenderManifestError(err)
+	}
+
+	return prepareObjects(it, manifests)
+}
+
+func prepareObjects(it *shipper.InstallationTarget, manifests []string) ([]runtime.Object, error) {
+	shipperLabels := labels.Merge(labels.Set(it.Labels), labels.Set{
+		shipper.InstallationTargetOwnerLabel: it.Name,
+	})
+
+	var (
+		allServices          []*corev1.Service
+		productionLBServices []*corev1.Service
+	)
+
+	preparedObjects := make([]runtime.Object, 0, len(manifests))
+	for _, manifest := range manifests {
+		decodedObj, _, err :=
+			kubescheme.Codecs.
+				UniversalDeserializer().
+				Decode([]byte(manifest), nil, nil)
+
+		if err != nil {
+			return nil, shippererrors.NewDecodeManifestError("error decoding manifest: %s", err)
+		}
+
+		switch obj := decodedObj.(type) {
+		case *appsv1.Deployment:
+			// We need the Deployment in the chart to have a unique
+			// name, meaning that different installations need to
+			// generate Deployments with different names,
+			// otherwise, we try to overwrite a previous
+			// Deployment, and that fails with a "field is
+			// immutable" error.
+			deploymentName := obj.Name
+			expectedName := it.Name
+			if !strings.Contains(deploymentName, expectedName) {
+				return nil, shippererrors.NewInvalidChartError(
+					fmt.Sprintf("Deployment %q has invalid name."+
+						" The name of the Deployment should be"+
+						" templated with {{.Release.Name}}.",
+						deploymentName),
+				)
+			}
+
+			decodedObj = patchDeployment(obj, shipperLabels)
+		case *corev1.Service:
+			allServices = append(allServices, obj)
+
+			lbValue, ok := obj.Labels[shipper.LBLabel]
+			if ok && lbValue == shipper.LBForProduction {
+				productionLBServices = append(productionLBServices, obj)
+			}
+		}
+
+		obj := decodedObj.(kubeobj)
+		obj.SetLabels(labels.Merge(
+			obj.GetLabels(),
+			shipperLabels,
+		))
+
+		preparedObjects = append(preparedObjects, obj)
+	}
+
+	// If we have observed only 1 Service object and it was not marked with
+	// shipper-lb=production label, we can do it ourselves.
+	if len(productionLBServices) == 0 && len(allServices) == 1 {
+		productionLBServices = allServices
+	}
+
+	// If, after all, we still can not identify a single Service which will
+	// be the production LB, there is nothing else to do rather than bail
+	// out
+	if len(productionLBServices) != 1 {
+		return nil, shippererrors.NewInvalidChartError(
+			fmt.Sprintf(
+				"one and only one v1.Service object with label %q is required, but %d found instead",
+				shipper.LBLabel, len(productionLBServices)))
+	}
+
+	err := patchService(it, productionLBServices[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return preparedObjects, nil
+}
+
+func patchDeployment(d *appsv1.Deployment, labelsToInject map[string]string) runtime.Object {
+	replicas := int32(0)
+	d.Spec.Replicas = &replicas
+
+	var newSelector *metav1.LabelSelector
+	if d.Spec.Selector != nil {
+		newSelector = d.Spec.Selector.DeepCopy()
+	} else {
+		newSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{},
+		}
+	}
+
+	for k, v := range labelsToInject {
+		newSelector.MatchLabels[k] = v
+	}
+	d.Spec.Selector = newSelector
+
+	podTemplateLabels := d.Spec.Template.Labels
+	for k, v := range labelsToInject {
+		podTemplateLabels[k] = v
+	}
+	d.Spec.Template.SetLabels(podTemplateLabels)
+
+	return d
+}
+
+func patchService(it *shipper.InstallationTarget, s *corev1.Service) error {
+	if relName, ok := s.Spec.Selector[shipper.HelmReleaseLabel]; ok {
+		v, ok := it.Labels[shipper.HelmWorkaroundLabel]
+		if ok && v == shipper.True {
+			// This selector label is native to helm-bootstrapped charts.
+			// In order to make it work the shipper way, we remove the
+			// label and proceed normally. With one little twist: the user
+			// has to ask shipper to do it explicitly.
+			if relName == it.Name {
+				delete(s.Spec.Selector, shipper.HelmReleaseLabel)
+			}
+		} else if !ok || v == shipper.False {
+			return shippererrors.NewInvalidChartError(
+				fmt.Sprintf("The chart contains %q label in Service object %q. This will"+
+					" break shipper traffic shifting logic. Consider adding the workaround"+
+					" label %q: true to your Application object",
+					shipper.HelmReleaseLabel, s.Name, shipper.HelmWorkaroundLabel))
+		} else {
+			return shippererrors.NewInvalidChartError(
+				fmt.Sprintf("Unexpected value for label %q: %q. Expected values: %s/%s.",
+					shipper.HelmWorkaroundLabel, v, shipper.True, shipper.False))
+		}
+	}
+
+	s.Labels[shipper.LBLabel] = shipper.LBForProduction
+	s.Spec.Selector[shipper.AppLabel] = s.Labels[shipper.AppLabel]
+	s.Spec.Selector[shipper.PodTrafficStatusLabel] = shipper.Enabled
+
+	return nil
+}


### PR DESCRIPTION
This builds on top of #250, so make sure that's merged before going through the changes here.

Previously, we were doing a whole dance for each cluster where we
intended to install some objects: download and decompress a chart, parse
a bunch of YAML, and iterate over all objects to make sure they are
valid. The thing is, this process works exactly the same for all
clusters, so why not extract it to somewhere where it can be done only
once, and reused for each cluster?

This has a small bonus as well: the InstallationTarget can report any
errors during this validation on the top level Operational condition
just once, instead of several times in the cluster conditions.