### PR TITLE
scheduler: wrap mismatched owner references in a shipper error

### DIFF
--- a/pkg/client/listers/shipper/v1alpha1/release_expansion.go
+++ b/pkg/client/listers/shipper/v1alpha1/release_expansion.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"sort"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
@@ -28,11 +27,6 @@ type ReleaseNamespaceListerExpansion interface {
 	// IncumbentForApplication returns the incumbent Release for the given
 	// application name.
 	IncumbentForApplication(appName string) (*shipper.Release, error)
-
-	// ReleaseForInstallationTarget returns the Release associated with given
-	// InstallationTarget. The relationship is established through owner
-	// references.
-	ReleaseForInstallationTarget(it *shipper.InstallationTarget) (*shipper.Release, error)
 }
 
 func (s releaseNamespaceLister) ReleasesForApplication(appName string) ([]*shipper.Release, error) {
@@ -68,32 +62,4 @@ func (s releaseNamespaceLister) IncumbentForApplication(appName string) (*shippe
 	}
 	sort.Sort(releaseutil.ByGenerationDescending(rels))
 	return apputil.GetIncumbent(appName, rels)
-}
-
-func (s releaseNamespaceLister) ReleaseForInstallationTarget(it *shipper.InstallationTarget) (*shipper.Release, error) {
-	owner, err := extractOwnerReference(it.ObjectMeta)
-	if err != nil {
-		return nil, err
-	}
-
-	rel, err := s.Get(owner.Name)
-	if err != nil {
-		return nil, shippererrors.NewKubeclientGetError(s.namespace, owner.Name, err).
-			WithShipperKind("Release")
-	}
-
-	if rel.UID != owner.UID {
-		return nil, shippererrors.NewWrongOwnerReferenceError(it.Name, it.UID, rel.UID)
-	}
-
-	return rel, nil
-}
-
-// extractOwnerReference returns an owner reference for the given object meta,
-// or an error in the case there are multiple or no owner references.
-func extractOwnerReference(it metav1.ObjectMeta) (*metav1.OwnerReference, error) {
-	if n := len(it.OwnerReferences); n != 1 {
-		return nil, shippererrors.NewMultipleOwnerReferencesError(it.Name, n)
-	}
-	return &it.OwnerReferences[0], nil
 }

--- a/pkg/controller/release/scheduler_test.go
+++ b/pkg/controller/release/scheduler_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetesting "k8s.io/client-go/testing"
@@ -22,6 +21,7 @@ import (
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
+	shippererrors "github.com/bookingcom/shipper/pkg/errors"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 )
@@ -688,8 +688,8 @@ func TestCreateAssociatedObjectsDuplicateInstallationTargetSameOwner(t *testing.
 
 // TestCreateAssociatedObjectsDuplicateInstallationTargetNoOwner tests a case
 // where an installationtarget object already exists but it does not belong to
-// the propper release. This is an exception and we expect a conflict error to
-// be returned.
+// the propper release. This is an exception and we expect the appropriate
+// error to be returned.
 func TestCreateAssociatedObjectsDuplicateInstallationTargetNoOwner(t *testing.T) {
 	cluster := buildCluster("minikube-a")
 	release := buildRelease()
@@ -718,8 +718,8 @@ func TestCreateAssociatedObjectsDuplicateInstallationTargetNoOwner(t *testing.T)
 		t.Fatalf("Expected an error here, none received")
 	}
 
-	if !errors.IsConflict(err) {
-		t.Fatalf("Expected a conflict error, got: %s", err)
+	if !shippererrors.IsWrongOwnerReferenceError(err) {
+		t.Fatalf("Expected a WrongOwnerReferenceError error, got: %s", err)
 	}
 }
 
@@ -784,7 +784,7 @@ func TestCreateAssociatedObjectsDuplicateTrafficTargetSameOwner(t *testing.T) {
 
 // TestCreateAssociatedObjectsDuplicateTrafficTargetNoOwner tests a case where
 // and existing traffictarget object exists but has a wrong owner reference.
-// It's an exception case and we expect a conflict error.
+// It's an exception case and we expect the appropriate error to be returned.
 func TestCreateAssociatedObjectsDuplicateTrafficTargetNoOwner(t *testing.T) {
 	// Fixtures
 	cluster := buildCluster("minikube-a")
@@ -815,8 +815,8 @@ func TestCreateAssociatedObjectsDuplicateTrafficTargetNoOwner(t *testing.T) {
 		t.Fatalf("Expected an error here, none received")
 	}
 
-	if !errors.IsConflict(err) {
-		t.Fatalf("Expected a conflict error, got: %s", err)
+	if !shippererrors.IsWrongOwnerReferenceError(err) {
+		t.Fatalf("Expected a WrongOwnerReferenceError error, got: %s", err)
 	}
 }
 
@@ -881,7 +881,7 @@ func TestCreateAssociatedObjectsDuplicateCapacityTargetSameOwner(t *testing.T) {
 
 // TestCreateAssociatedObjectsDuplicateCapacityTargetNoOwner tests a case where
 // a capacitytarget object already exists but it has a wrong owner reference.
-// It's an exception and we expect a conflict error.
+// It's an exception and we expect the appropriate error to be returned.
 func TestCreateAssociatedObjectsDuplicateCapacityTargetNoOwner(t *testing.T) {
 	// Fixtures
 	cluster := buildCluster("minikube-a")
@@ -911,8 +911,8 @@ func TestCreateAssociatedObjectsDuplicateCapacityTargetNoOwner(t *testing.T) {
 		t.Fatalf("Expected an error here, none received")
 	}
 
-	if !errors.IsConflict(err) {
-		t.Fatalf("Expected a conflict error, got: %s", err)
+	if !shippererrors.IsWrongOwnerReferenceError(err) {
+		t.Fatalf("Expected a WrongOwnerReferenceError error, got: %s", err)
 	}
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,8 +4,18 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
 )
+
+// kubeobj is close to an union of Object and Type, as there's no interface in
+// apimachinery that has them both together, and it's used in a few places here
+// to get k8s objects as a parameter.
+type kubeobj interface {
+	GetName() string
+	GetNamespace() string
+	GroupVersionKind() schema.GroupVersionKind
+}
 
 // RetryAware is an error that knows if the action that caused it should be
 // retried.

--- a/pkg/errors/kubeclient.go
+++ b/pkg/errors/kubeclient.go
@@ -88,12 +88,6 @@ func (e KubeclientError) WithCoreV1Kind(kind string) KubeclientError {
 	return e.WithKind(corev1.SchemeGroupVersion.WithKind(kind))
 }
 
-type kubeobj interface {
-	GetName() string
-	GetNamespace() string
-	GroupVersionKind() schema.GroupVersionKind
-}
-
 func NewKubeclientErrorFromObject(verb KubeclientVerb, obj kubeobj, err error) KubeclientError {
 	return NewKubeclientError(verb, obj.GetNamespace(), obj.GetName(), err)
 }


### PR DESCRIPTION
This prevents shipper from making assumptions on whether to retry errors
cause by mismatched owner references for target objects:

	Cannot determine if untagged error &errors.StatusError{...} is
	retriable, will assume it is

This should be a non-retriable error, as it's an unrecoverable condition
for shipper. This happens when a release is deleted and then re-created,
and the correct course of action is for shipper to wait for kubernetes
to garbage collect the old target objects, which will trigger a new sync
of the Release, which can then create the new objects correctly.