### PR TITLE
Reworked the synchronisation part of chart repo index fetcher

### DIFF
--- a/pkg/chart/repo/repo_test.go
+++ b/pkg/chart/repo/repo_test.go
@@ -430,10 +430,10 @@ func TestFetchChartVersionsTimesOut(t *testing.T) {
 		t.Fatalf("Expected to receive an error, got: nil")
 	}
 
-	var resolveErr shippererrors.ChartVersionResolveError
+	var resolveErr shippererrors.NoCachedChartRepoIndexError
 
 	if !errors.As(err, &resolveErr) {
-		t.Fatalf("unexpected error type returned: expected: ChartVersionResolveError, got: %#v", err)
+		t.Fatalf("unexpected error type returned: expected: NoCachedChartRepoIndexError, got: %#v", err)
 	}
 }
 


### PR DESCRIPTION
This commit changes the strategy for chart version resolution slightly.
In the current implementation we're waiting until the first resolution
of chart repo index and start serving this data. The modified version
proposed to return an instant error indicating there is no cached index
result yet and moving forward with the rest of the apps. This approach
lets us unblock the processing loop of application controller and
eliminate blockage by unhealthy chart repo URLs. Theoretically this
creates more load on etcd as the majority of the application objects
would get an error condition at Shipper restart moment. We accept this
flaw in favour of non-blocking version resolution strategy and global
processing speedup.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>