### PR TITLE
installer: reuse dynamic resource clients for the same gvk

### DIFF
--- a/pkg/controller/installation/installer_test.go
+++ b/pkg/controller/installation/installer_test.go
@@ -407,7 +407,6 @@ func TestInstallerMultiServiceWithLB(t *testing.T) {
 		kubetesting.NewGetAction(schema.GroupVersionResource{Resource: "configmaps", Version: "v1"}, testNs, "0.0.1-anchor"),
 		kubetesting.NewCreateAction(schema.GroupVersionResource{Resource: "configmaps", Version: "v1"}, testNs, nil),
 		shippertesting.NewDiscoveryAction("services"),
-		shippertesting.NewDiscoveryAction("services"),
 		shippertesting.NewDiscoveryAction("deployments"),
 	}
 
@@ -460,7 +459,6 @@ func TestInstallerMultiServiceWithLBOffTheShelf(t *testing.T) {
 	expectedActions := []kubetesting.Action{
 		kubetesting.NewGetAction(schema.GroupVersionResource{Resource: "configmaps", Version: "v1"}, testNs, "0.1.0-anchor"),
 		kubetesting.NewCreateAction(schema.GroupVersionResource{Resource: "configmaps", Version: "v1"}, testNs, nil),
-		shippertesting.NewDiscoveryAction("services"),
 		shippertesting.NewDiscoveryAction("services"),
 		shippertesting.NewDiscoveryAction("deployments"),
 	}


### PR DESCRIPTION
Building a resource client always takes a round trip to an API server
for discovery. Whenever we're installing a chart that contains several
objects of the same GroupVersionKind, there's a little bit of waste.
During normal operations, that's totally acceptable, as usually you're
not rolling out hundreds of releases at once.

This is a very big problem when Shipper is starting up though: it'll
verify that every single InstallationTarget matches the state of the
clusters, and that can become a very large number very fast. The first
place where it hurts is throttling: we don't want to overload API
servers, so we have some client-side rate limiting in place, and
discovery *does* count towards that limit. Here, we avoid some of those
duplicated discovery requests, and re-use resource clients wherever
possible.

Note that we don't reuse resource clients across clusters, nor across
InstallationTargets. We don't do it across clusters to guard against
different GVRs between them (different versions, or a resource existing
in a cluster but not in another). We *could* in theory reuse them
between InstallationTargets, but we'd need some cache invalidation in
place (for a similar reason as before: GVRs can change over time), and a
fairly large amount of code churn, so we'll leave that for another day,
if ever.