### PR TITLE
traffic controller: sort pods to shift

### DIFF
--- a/pkg/controller/traffic/traffic_controller_test.go
+++ b/pkg/controller/traffic/traffic_controller_test.go
@@ -328,7 +328,7 @@ func assertPodTraffic(
 
 	pods, err := meta.ExtractList(list)
 	if err != nil {
-		t.Errorf("could not extrat list of Pods: %s", err)
+		t.Errorf("could not extract list of Pods: %s", err)
 		return
 	}
 

--- a/pkg/controller/traffic/traffic_shifting_status.go
+++ b/pkg/controller/traffic/traffic_shifting_status.go
@@ -2,6 +2,7 @@ package traffic
 
 import (
 	"math"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -137,6 +138,10 @@ func summarizePods(
 ) (map[string][]*corev1.Pod, int, int, int) {
 	podsInRelease := make(map[string]struct{})
 	podsByTrafficStatus := make(map[string][]*corev1.Pod)
+
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
 
 	for _, pod := range pods {
 		if !releaseSelector.Matches(labels.Set(pod.Labels)) {


### PR DESCRIPTION
This avoids a (benign?) race condition where we could patch the same
pods several times to have traffic labels, due to unstable order.
Although this eventually converges in the wild, it was causing one of
the tests to flake every once in a while.