### PR TITLE
ReleaseController detects target step inconsistencies

### DIFF
--- a/pkg/errors/release.go
+++ b/pkg/errors/release.go
@@ -194,3 +194,26 @@ func NewNotWorkingOnStrategyError(contenderReleaseKey string) NotWorkingOnStrate
 		contenderReleaseKey: contenderReleaseKey,
 	}
 }
+
+type InconsistentReleaseTargetStep struct {
+	relKey         string
+	gotTargetStep  int32
+	wantTargetStep int32
+}
+
+func (e InconsistentReleaseTargetStep) Error() string {
+	return fmt.Sprintf("Release %s target step is inconsistent: unexpected value %d (expected: %d)",
+		e.relKey, e.gotTargetStep, e.wantTargetStep)
+}
+
+func (e InconsistentReleaseTargetStep) ShouldRetry() bool {
+	return false
+}
+
+func NewInconsistentReleaseTargetStep(relKey string, gotTargetStep, wantTargetStep int32) InconsistentReleaseTargetStep {
+	return InconsistentReleaseTargetStep{
+		relKey:         relKey,
+		gotTargetStep:  gotTargetStep,
+		wantTargetStep: wantTargetStep,
+	}
+}

--- a/pkg/util/release/environment.go
+++ b/pkg/util/release/environment.go
@@ -18,3 +18,9 @@ func ReleaseAchievedTargetStep(rel *shipper.Release) bool {
 	}
 	return rel.Status.AchievedStep.Step == rel.Spec.TargetStep
 }
+
+func IsLastStrategyStep(rel *shipper.Release) bool {
+	targetStep := rel.Spec.TargetStep
+	numSteps := len(rel.Spec.Environment.Strategy.Steps)
+	return targetStep == int32(numSteps-1)
+}


### PR DESCRIPTION
This commit proposes a change to ReleaseController which makes it review
the consistency of the release timeline. The idea is that a release
targetStep can never be less than it's successor's, otherwise this
situation can provoke shipper to reactivate a historical release. This
commit ensures a release in an inconsistent state can not be
reactivated.

This commit might be not the final version and is aiming to spawn a discussion about the desired shipper behavior in a case of inconsistency. During the verbal discussion, we concluded there are 2 major ways: autocorrecting the targetStep or to bail out and expect the user to get it fixed.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>