### PR TITLE
ci: replace microk8s with kind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,16 @@ dist: xenial
 services:
 - docker
 before_install:
-- sudo snap install microk8s --classic --channel=1.15/stable
-- curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.6/bin/linux/amd64/kubectl > $(go env GOPATH)/bin/kubectl
+- curl -L https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kubectl > $(go env GOPATH)/bin/kubectl
 - chmod +x $(go env GOPATH)/bin/kubectl
-- mkdir ~/.kube
-- sudo microk8s.config > ~/.kube/config
+
+- curl -L "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64" > $(go env GOPATH)/bin/kind
+- chmod +x $(go env GOPATH)/bin/kind
+
 - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh |
-  sh -s -- -b $(go env GOPATH)/bin v1.21.0
-- sudo microk8s.status --wait-ready
-- sudo microk8s.enable registry
+  sh -s -- -b $(go env GOPATH)/bin v1.23.3
+
+- ./ci/setup_clusters.sh
 install: true
 script:
 - "./ci/test.sh && ./ci/build.sh && ./ci/e2e.sh"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHIPPER_CLUSTERS_YAML ?= ci/clusters.yaml
 # that errors out, or returns nothing, you probably need to run `make setup`
 # first. This value needs to be present in the `applicationClusters` section in
 # $(SHIPPER_CLUSTERS_YAML).
-SHIPPER_CLUSTER ?= kind-kind
+SHIPPER_CLUSTER ?= kind-app
 
 # Defines optional flags to pass to `build/e2e.test` when running end-to-end
 # tests. Useful flags are "-inspectfailed" (keep namespaces used for tests that

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHIPPER_CLUSTERS_YAML ?= ci/clusters.yaml
 # that errors out, or returns nothing, you probably need to run `make setup`
 # first. This value needs to be present in the `applicationClusters` section in
 # $(SHIPPER_CLUSTERS_YAML).
-SHIPPER_CLUSTER ?= microk8s
+SHIPPER_CLUSTER ?= kind-kind
 
 # Defines optional flags to pass to `build/e2e.test` when running end-to-end
 # tests. Useful flags are "-inspectfailed" (keep namespaces used for tests that

--- a/ci/clusters.yaml
+++ b/ci/clusters.yaml
@@ -1,5 +1,6 @@
 managementClusters:
-- name: microk8s
+- name: kind-kind
 applicationClusters:
-- name: microk8s
+- name: kind-kind
   region: local
+  apimaster: kubernetes.default:443

--- a/ci/clusters.yaml
+++ b/ci/clusters.yaml
@@ -1,6 +1,5 @@
 managementClusters:
-- name: kind-kind
+- name: kind-mgmt
 applicationClusters:
-- name: kind-kind
+- name: kind-app
   region: local
-  apimaster: kubernetes.default:443

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -4,7 +4,11 @@
 make setup
 
 # Run the e2e tests, save exit code for later
-TEST_HELM_REPO_URL=${TEST_HELM_REPO_URL:=https://raw.githubusercontent.com/bookingcom/shipper/${TRAVIS_COMMIT}/test/e2e/testdata} DOCKER_REGISTRY=${DOCKER_REGISTRY:=localhost:32000} E2E_FLAGS="--test.v" make -j e2e
+make -j e2e \
+	TEST_HELM_REPO_URL=${TEST_HELM_REPO_URL:=https://raw.githubusercontent.com/bookingcom/shipper/${TRAVIS_COMMIT}/test/e2e/testdata} \
+	DOCKER_REGISTRY=${DOCKER_REGISTRY:=registry:5000} \
+	E2E_FLAGS="--test.v" \
+
 TEST_STATUS=$?
 
 # Remove yaml artifacts that we no longer need, so they don't end up in

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -x
 
-# Setup shipper's clusters in microk8s
+kubectl config use-context kind-mgmt
+
+# Setup shipper's clusters
 make setup
 
 # Run the e2e tests, save exit code for later
 make -j e2e \
 	TEST_HELM_REPO_URL=${TEST_HELM_REPO_URL:=https://raw.githubusercontent.com/bookingcom/shipper/${TRAVIS_COMMIT}/test/e2e/testdata} \
 	DOCKER_REGISTRY=${DOCKER_REGISTRY:=registry:5000} \
-	E2E_FLAGS="--test.v" \
+	E2E_FLAGS="--test.v"
 
 TEST_STATUS=$?
 

--- a/ci/kind.yaml
+++ b/ci/kind.yaml
@@ -7,6 +7,3 @@ containerdConfigPatches:
     endpoint = ["http://registry:5000"]
 nodes:
 - role: control-plane
-  extraPortMappings:
-  - containerPort: 6443
-    hostPort: 443

--- a/ci/kind.yaml
+++ b/ci/kind.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
+    endpoint = ["http://registry:5000"]
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 6443
+    hostPort: 443

--- a/ci/setup_clusters.sh
+++ b/ci/setup_clusters.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+	docker run \
+		-d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+		registry:2
+fi
+
+kind create cluster --name $KIND_CLUSTER_NAME --config ci/kind.yaml --image kindest/node:v1.15.7
+
+# add the registry to /etc/hosts on each node
+ip_fmt='{{.NetworkSettings.IPAddress}}'
+cmd="echo $(docker inspect -f "${ip_fmt}" "${reg_name}") registry >> /etc/hosts"
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+	docker exec "${node}" sh -c "${cmd}"
+done
+
+# add the registry to /etc/hosts on the host
+echo "127.0.0.1 registry kubernetes.default" | sudo tee -a /etc/hosts

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1432,7 +1432,7 @@ func TestDeletedDeploymentsAreReinstalled(t *testing.T) {
 
 	deploymentName := fmt.Sprintf("%s-%s", rel.GetName(), newApp.Spec.Template.Chart.Name)
 	t.Logf("deleting deployment %q", deploymentName)
-	err = kubeClient.AppsV1().Deployments(ns.GetName()).Delete(deploymentName, nil)
+	err = appKubeClient.AppsV1().Deployments(ns.GetName()).Delete(deploymentName, nil)
 	if err != nil {
 		t.Fatalf("could not delete deployment %q: %q", deploymentName, err)
 	}

--- a/test/e2e/e2e_util.go
+++ b/test/e2e/e2e_util.go
@@ -75,7 +75,7 @@ func (f *fixture) checkReadyPods(relName string, expectedCount int) []corev1.Pod
 }
 
 func (f *fixture) checkEndpointActivePods(epName string, pods []corev1.Pod) {
-	ep, err := kubeClient.CoreV1().Endpoints(f.namespace).Get(epName, metav1.GetOptions{})
+	ep, err := appKubeClient.CoreV1().Endpoints(f.namespace).Get(epName, metav1.GetOptions{})
 	if err != nil {
 		f.t.Fatalf("could not fetch endpoint %q: %q", epName, err)
 	}
@@ -284,6 +284,11 @@ func poll(timeout time.Duration, waitCondition func() (bool, error)) error {
 
 func setupNamespace(name string) (*corev1.Namespace, error) {
 	newNs := testNamespace(name)
+	_, err := appKubeClient.CoreV1().Namespaces().Create(newNs)
+	if err != nil {
+		return nil, err
+	}
+
 	return kubeClient.CoreV1().Namespaces().Create(newNs)
 }
 


### PR DESCRIPTION
microk8s tends to sneak in breaking changes for the same version, and
that's caused a lot of miscellaneous heartbreak for us over time
(f18b24d and 46d74fe, for example, on top of a lot of stuff during
development). It also doesn't allow us to run several separate clusters
in the same environment, which will be useful to us as shipper is a
multi-cluster piece of software.

Closes #271. By some magic, without addressing #197 yet.