### PR TITLE
Release StrategyExecutor aborts if successor release is progressing

### DIFF
--- a/pkg/testing/util.go
+++ b/pkg/testing/util.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pmezard/go-difflib/difflib"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubetesting "k8s.io/client-go/testing"
@@ -99,7 +100,7 @@ func ShallowCheckAction(expected, actual kubetesting.Action, t *testing.T) {
 // CheckAction compares two individual actions and calls Errorf on t if it finds
 // a difference.
 func CheckAction(expected, actual kubetesting.Action, t *testing.T) {
-	if !reflect.DeepEqual(expected, actual) {
+	if !equality.Semantic.DeepEqual(expected, actual) {
 		prettyExpected := prettyPrintAction(expected)
 		prettyActual := prettyPrintAction(actual)
 

--- a/pkg/util/release/environment.go
+++ b/pkg/util/release/environment.go
@@ -11,3 +11,10 @@ func HasEmptyEnvironment(rel *shipper.Release) bool {
 		len(rel.Spec.Environment.ClusterRequirements.Regions) == 0 &&
 		len(rel.Spec.Environment.ClusterRequirements.Capabilities) == 0
 }
+
+func ReleaseAchievedTargetStep(rel *shipper.Release) bool {
+	if rel == nil || rel.Status.AchievedStep == nil {
+		return false
+	}
+	return rel.Status.AchievedStep.Step == rel.Spec.TargetStep
+}


### PR DESCRIPTION
This release is a fix of a problem with the new implementation of the
reconciliation loop involving strategy execution for all release (as
opposed to apply it to contender-incumbent pair only in the old
implementation). The problem we observed boiled down to the next
scenario:
  1. A contender runs through the strategy execution loop and bails out
  with an incomplete state.
  2. Incumbent enters it's independent strategy loop and checks it's
  desired state from the desired state of the contender. This is the
  point where the things broke: desired state != achieved state. At this
  moment incumbent can start progressing without waiting for it's
  successor (contender) to complete.

This optimistic triggering was not a planned action and was mainly
mistakenly introduced because distinct release generations are being
processed independently now.

Preventing the strategy loop from progressing is one way to get around
this problem where releases are being processed independently. Another
alternative to that could be: an incumbent release can be smarter in
terms of figuring out it's desired state itself (e.g. if it's successor
hasn't achieved it's target step yet, try to reconcile on the last
step in it's own strategy). This behavior has pros and cons of course.
On the bright side: releases can behave much more independently and this
can also challenge the need for incumbent and contender strategy states.
On the lowlight, this might provoke some unwanted chatting and flapping
in the release squad. Chatty releases might be quite expensive in terms
of converging to a stable state (as we now provoke a direct and reverse
chain reaction when there is a change to a release object).

For now, we settle down with an easy patch which prevents the system
from doing unwanted things. This approach might be a subject for change
in the future.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>