### PR TITLE
Fixed out-of-range index dereferencing error in release controller

### DIFF
--- a/pkg/controller/release/strategy_executor.go
+++ b/pkg/controller/release/strategy_executor.go
@@ -8,22 +8,9 @@ import (
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	"github.com/bookingcom/shipper/pkg/controller"
-	shippererrors "github.com/bookingcom/shipper/pkg/errors"
 	"github.com/bookingcom/shipper/pkg/util/conditions"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 )
-
-type StrategyExecutor struct {
-	curr, prev, succ *releaseInfo
-}
-
-func NewStrategyExecutor(prev, curr, succ *releaseInfo) *StrategyExecutor {
-	return &StrategyExecutor{
-		prev: prev,
-		curr: curr,
-		succ: succ,
-	}
-}
 
 type PipelineContinuation bool
 
@@ -49,19 +36,106 @@ type Extra struct {
 	HasIncumbent bool
 }
 
-func (p *Pipeline) Process(strategy *shipper.RolloutStrategy, targetStep int32, extra Extra, cond conditions.StrategyConditionsMap) (bool, []StrategyPatch, []ReleaseStrategyStateTransition) {
-	var res []StrategyPatch
+func (p *Pipeline) Process(strategy *shipper.RolloutStrategy, step int32, extra Extra, cond conditions.StrategyConditionsMap) (bool, []StrategyPatch, []ReleaseStrategyStateTransition) {
+	var patches []StrategyPatch
 	var trans []ReleaseStrategyStateTransition
-	for _, step := range *p {
-		cont, stepres, steptrans := step(strategy, targetStep, extra, cond)
-		res = append(res, stepres...)
+	for _, stage := range *p {
+		cont, steppatches, steptrans := stage(strategy, step, extra, cond)
+		patches = append(patches, steppatches...)
 		trans = append(trans, steptrans...)
 		if cont == PipelineBreak {
-			return false, res, trans
+			return false, patches, trans
 		}
 	}
 
-	return true, res, trans
+	return true, patches, trans
+}
+
+type StrategyExecutor struct {
+	strategy *shipper.RolloutStrategy
+	step     int32
+}
+
+func NewStrategyExecutor(strategy *shipper.RolloutStrategy, step int32) *StrategyExecutor {
+	return &StrategyExecutor{
+		strategy: strategy,
+		step:     step,
+	}
+}
+
+/*
+	For each release object:
+	0. Ensure release scheduled.
+	  0.1. Choose clusters.
+	  0.2. Ensure target objects exist.
+	    0.2.1. Compare chosen clusters and if different, update the spec.
+	1. Find it's ancestor.
+	2. For the head release, ensure installation.
+	  2.1. Simply check installation targets.
+	3. For the head release, ensure capacity.
+	  3.1. Ensure the capacity corresponds to the strategy contender.
+	4. For the head release, ensure traffic.
+	  4.1. Ensure the traffic corresponds to the strategy contender.
+	5. For a tail release, ensure traffic.
+	  5.1. Look at the leader and check it's target traffic.
+	  5.2. Look at the strategy and figure out the target traffic.
+	6. For a tail release, ensure capacity.
+	  6.1. Look at the leader and check it's target capacity.
+	  6.2 Look at the strategy and figure out the target capacity.
+	7. Make necessary adjustments to the release object.
+*/
+
+func (e *StrategyExecutor) Execute(prev, curr, succ *releaseInfo) (bool, []StrategyPatch, []ReleaseStrategyStateTransition) {
+	isHead, hasTail := succ == nil, prev != nil
+	hasIncumbent := prev != nil || succ != nil
+
+	// There is no really a point in making any changes until the successor
+	// has completed it's transition, therefore we're hoilding off and aborting
+	// the pipeline execution. An alternative to this approach could be to make
+	// an autonomous move purely based on the picture of the world. But due to
+	// the limited visilibility of what's happening to the successor (as it
+	// might be following it's successor) it could be that a preliminary action
+	// would create more noise than help really.
+	if !isHead {
+		if !releaseutil.ReleaseAchievedTargetStep(succ.release) {
+			return false, nil, nil
+		}
+	}
+
+	var releaseStrategyConditions []shipper.ReleaseStrategyCondition
+	if curr.release.Status.Strategy != nil {
+		releaseStrategyConditions = curr.release.Status.Strategy.Conditions
+	}
+	cond := conditions.NewStrategyConditions(releaseStrategyConditions...)
+
+	// the last step is slightly special from others: at this moment shipper
+	// no longer waits for a command but marks a release as complete.
+	isLastStep := int(e.step) == len(e.strategy.Steps)-1
+	// The reason because isHead is not included in the extra set is mainly
+	// because the pipeline is picking up 2 distinct tuples of releases
+	// (curr+succ) and (prev+curr), therefore isHead is supposed to be
+	// calculated by enforcers.
+	extra := Extra{
+		HasIncumbent: hasIncumbent,
+		IsLastStep:   isLastStep,
+	}
+
+	pipeline := NewPipeline()
+	if isHead {
+		pipeline.Enqueue(genInstallationEnforcer(curr, nil))
+	}
+	pipeline.Enqueue(genCapacityEnforcer(curr, succ))
+	pipeline.Enqueue(genTrafficEnforcer(curr, succ))
+
+	if isHead {
+		if hasTail {
+			pipeline.Enqueue(genTrafficEnforcer(prev, curr))
+			pipeline.Enqueue(genCapacityEnforcer(prev, curr))
+		}
+		pipeline.Enqueue(genReleaseStrategyStateEnforcer(curr, nil))
+	}
+
+	return pipeline.Process(e.strategy, e.step, extra, cond)
 }
 
 func genInstallationEnforcer(curr, succ *releaseInfo) PipelineStep {
@@ -272,104 +346,6 @@ func genReleaseStrategyStateEnforcer(curr, succ *releaseInfo) PipelineStep {
 
 		return PipelineContinue, patches, releaseStrategyStateTransitions
 	}
-}
-
-/*
-	For each release object:
-	0. Ensure release scheduled.
-	  0.1. Choose clusters.
-	  0.2. Ensure target objects exist.
-	    0.2.1. Compare chosen clusters and if different, update the spec.
-	1. Find it's ancestor.
-	2. For the head release, ensure installation.
-	  2.1. Simply check installation targets.
-	3. For the head release, ensure capacity.
-	  3.1. Ensure the capacity corresponds to the strategy contender.
-	4. For the head release, ensure traffic.
-	  4.1. Ensure the traffic corresponds to the strategy contender.
-	5. For a tail release, ensure traffic.
-	  5.1. Look at the leader and check it's target traffic.
-	  5.2. Look at the strategy and figure out the target traffic.
-	6. For a tail release, ensure capacity.
-	  6.1. Look at the leader and check it's target capacity.
-	  6.2 Look at the strategy and figure out the target capacity.
-	7. Make necessary adjustments to the release object.
-*/
-
-func (e *StrategyExecutor) Execute() (bool, []StrategyPatch, []ReleaseStrategyStateTransition, error) {
-	isHead, hasTail := e.succ == nil, e.prev != nil
-	hasIncumbent := e.prev != nil || e.succ != nil
-
-	// There is no really a point in making any changes until the successor
-	// has completed it's transition, therefore we're hoilding off and aborting
-	// the pipeline execution. An alternative to this approach could be to make
-	// an autonomous move purely based on the picture of the world. But due to
-	// the limited visilibility of what's happening to the successor (as it
-	// might be following it's successor) it could be that a preliminary action
-	// would create more noise than help really.
-	if !isHead {
-		if !releaseutil.ReleaseAchievedTargetStep(e.succ.release) {
-			return false, nil, nil, nil
-			//shippererrors.NewContenderStrategyIncompleteError(
-			//	controller.MetaKey(e.succ.release))
-		}
-	}
-
-	var releaseStrategyConditions []shipper.ReleaseStrategyCondition
-	if e.curr.release.Status.Strategy != nil {
-		releaseStrategyConditions = e.curr.release.Status.Strategy.Conditions
-	}
-	cond := conditions.NewStrategyConditions(releaseStrategyConditions...)
-
-	var strategy *shipper.RolloutStrategy
-	var targetStep int32
-
-	// A head release uses it's local spec-defined strategy, any other release
-	// follows it's successor state, therefore looking into the forecoming spec.
-	if isHead {
-		strategy = e.curr.release.Spec.Environment.Strategy
-		targetStep = e.curr.release.Spec.TargetStep
-	} else {
-		strategy = e.succ.release.Spec.Environment.Strategy
-		targetStep = e.succ.release.Spec.TargetStep
-	}
-
-	// Looks like a malformed input. Informing about a problem and bailing out.
-	if targetStep >= int32(len(strategy.Steps)) {
-		err := fmt.Errorf("no step %d in strategy for Release %q",
-			targetStep, controller.MetaKey(e.curr.release))
-		return false, nil, nil, shippererrors.NewUnrecoverableError(err)
-	}
-
-	// the last step is slightly special from others: at this moment shipper
-	// no longer waits for a command but marks a release as complete.
-	isLastStep := int(targetStep) == len(strategy.Steps)-1
-	// The reason because isHead is not included in the extra set is mainly
-	// because the is picking up 2 distinct tuples of releases (curr+succ) and
-	// (prev+curr), therefore isHead is supposed to be calculated by enforcers.
-	extra := Extra{
-		HasIncumbent: hasIncumbent,
-		IsLastStep:   isLastStep,
-	}
-
-	pipeline := NewPipeline()
-	if isHead {
-		pipeline.Enqueue(genInstallationEnforcer(e.curr, nil))
-	}
-	pipeline.Enqueue(genCapacityEnforcer(e.curr, e.succ))
-	pipeline.Enqueue(genTrafficEnforcer(e.curr, e.succ))
-
-	if isHead {
-		if hasTail {
-			pipeline.Enqueue(genTrafficEnforcer(e.prev, e.curr))
-			pipeline.Enqueue(genCapacityEnforcer(e.prev, e.curr))
-		}
-		pipeline.Enqueue(genReleaseStrategyStateEnforcer(e.curr, nil))
-	}
-
-	complete, patches, trans := pipeline.Process(strategy, targetStep, extra, cond)
-
-	return complete, patches, trans, nil
 }
 
 func buildContenderStrategyConditionsPatch(


### PR DESCRIPTION
This commit fixes a problem where a corresponding release strategy was
resolved twice: once for an actual execution and second time for
reporting. These resolutions were happening in distinct places: the 1st
one in strategy executor, the latter in release controller. As a result,
the release controller one was causing a panic as it was not taking into
account the updated logic of strategy resolution where an incumbent is
supposed to look ahead and use it's successor's strategy, and the index
validity was only happening in strategy executor, which was calculating
the desired strategy correctly. This commit is also moving things
around: strategy executor is being initialized with a specific strategy
and a pointer to the target step and Execute() step takes the sequence
of executable releases as arguments.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>