### PR TITLE
Bugfixes in release controller strategy executor

### DIFF
--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -476,7 +476,6 @@ func (c *Controller) executeReleaseStrategy(relinfo *releaseInfo, diff *diffutil
 		} else {
 			achievedStep = int32(len(rel.Spec.Environment.Strategy.Steps)) - 1
 			achievedStepName = rel.Spec.Environment.Strategy.Steps[achievedStep].Name
-
 		}
 		if prevStep == nil || achievedStep != prevStep.Step {
 			rel.Status.AchievedStep = &shipper.AchievedStep{

--- a/pkg/controller/release/strategy_patches.go
+++ b/pkg/controller/release/strategy_patches.go
@@ -55,7 +55,7 @@ func (p *TrafficTargetSpecPatch) PatchSpec() (string, schema.GroupVersionKind, [
 }
 
 func (p *TrafficTargetSpecPatch) Alters(o interface{}) bool {
-	// CapacityTargetSpecPatch is an altering one by it's nature: it's only
+	// TrafficTargetSpecPatch is an altering one by it's nature: it's only
 	// being created if a capacity target adjustment is required. Therefore
 	// we're saving a few peanuts and moving on with always-apply strategy.
 	return !p.IsEmpty()


### PR DESCRIPTION
This commit addresses multiple issues identified in strategy executor,
among which:
  * Wrong recepients for patch updates: due to an error in the code some
  patches were applied to a wrong generation of release and target
  objects.
  * Target object spec checkers used to return an incomplete spec if
  only some of the clusters are misbehaving: there was a risk of
  de-scheduling the workload on healthy clusters.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>