### PR TITLE
Fixed historical release awakening due to targetStep resolve inconsistency

### DIFF
--- a/pkg/controller/release/strategy_executor.go
+++ b/pkg/controller/release/strategy_executor.go
@@ -127,14 +127,17 @@ func (e *StrategyExecutor) Execute(prev, curr, succ *releaseInfo) (bool, []Strat
 	}
 
 	pipeline := NewPipeline()
-	pipeline.Enqueue(genInstallationEnforcer(curr, nil))
+	if isHead {
+		pipeline.Enqueue(genInstallationEnforcer(curr, nil))
+	}
 	pipeline.Enqueue(genCapacityEnforcer(curr, succ))
 	pipeline.Enqueue(genTrafficEnforcer(curr, succ))
-	if hasTail {
-		pipeline.Enqueue(genTrafficEnforcer(prev, curr))
-		pipeline.Enqueue(genCapacityEnforcer(prev, curr))
-	}
+
 	if isHead {
+		if hasTail {
+			pipeline.Enqueue(genTrafficEnforcer(prev, curr))
+			pipeline.Enqueue(genCapacityEnforcer(prev, curr))
+		}
 		pipeline.Enqueue(genReleaseStrategyStateEnforcer(curr, nil))
 	}
 


### PR DESCRIPTION
Due to a change introduced in #285, shipper strarted re-activating
historical releases due to the way targetStep is resolved. The
aforementioned step changed the composition of the pipeline and caused
historical releases to be re-scheduled. This caused some historical
items to re-activate their capacity and target targets. This change
mainly reverts the re-composition of the pipeline and ensures the
historical releases never re-activate their predecessors.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>