### PR TITLE
Surface CapacityTarget issues in the release

### DIFF
--- a/crd/CapacityTarget-crd.yaml
+++ b/crd/CapacityTarget-crd.yaml
@@ -4,6 +4,23 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: capacitytargets.shipper.booking.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(.type=="Operational")].status
+    description: Whether the capacity target is operational.
+    name: Operational
+    type: string
+  - JSONPath: .status.conditions[?(.type=="Ready")].status
+    description: Whether the capacity target is ready.
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(.status=="False")].message
+    description: Reason for the capactiy target to not be ready or operational.
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The capacity target's age.
+    name: Age
+    type: date
   # group name to use for REST API: /apis/<group>/<version>
   group: shipper.booking.com
   # version name to use for REST API: /apis/<group>/<version>

--- a/pkg/controller/capacity/deployment_test.go
+++ b/pkg/controller/capacity/deployment_test.go
@@ -1,0 +1,87 @@
+package capacity
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+)
+
+func TestSummarizeSadPods(t *testing.T) {
+	sadPods := []shipper.PodStatus{
+		{
+			InitContainers: []corev1.ContainerStatus{
+				{
+					Name:  "ready-init-container",
+					Ready: true,
+				},
+				{
+					Name:  "waiting-init-container",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ImagePullBackOff",
+						},
+					},
+				},
+			},
+			Containers: []corev1.ContainerStatus{
+				{
+					Name:  "ready-container",
+					Ready: true,
+				},
+				{
+					Name:  "waiting-container",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ImagePullBackOff",
+						},
+					},
+				},
+				{
+					Name:  "terminated-container",
+					Ready: false,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason: "Completed",
+						},
+					},
+				},
+			},
+		},
+		{
+			InitContainers: []corev1.ContainerStatus{
+				{
+					Name:  "waiting-init-container", // but not really :D
+					Ready: true,
+				},
+			},
+			Containers: []corev1.ContainerStatus{
+				{
+					Name:  "waiting-container",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ErrImagePull",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := strings.Join([]string{
+		`1x"terminated-container" containers with [Completed]`,
+		`2x"waiting-container" containers with [ErrImagePull ImagePullBackOff]`,
+		`1x"waiting-init-container" containers with [ImagePullBackOff]`,
+	}, "; ")
+	actual := summarizeSadPods(sadPods)
+	if expected != actual {
+		t.Fatalf(
+			"summary does not match.\nexpected: %s\nactual:   %s",
+			expected, actual)
+	}
+}

--- a/pkg/controller/capacity/utils_test.go
+++ b/pkg/controller/capacity/utils_test.go
@@ -124,6 +124,17 @@ func buildSadPodForDeployment(deployment *appsv1.Deployment) *corev1.Pod {
 					Message: "This failure is meant to happen!",
 				},
 			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "app",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ExpectedFail",
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/crds/capacitytarget.go
+++ b/pkg/crds/capacitytarget.go
@@ -64,5 +64,31 @@ var CapacityTarget = &apiextensionv1beta1.CustomResourceDefinition{
 				},
 			},
 		},
+		AdditionalPrinterColumns: []apiextensionv1beta1.CustomResourceColumnDefinition{
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Operational",
+				Type:        "string",
+				Description: "Whether the capactiy target is operational.",
+				JSONPath:    `.status.conditions[?(.type=="Operational")].status`,
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Ready",
+				Type:        "string",
+				Description: "Whether the capactiy target is ready.",
+				JSONPath:    `.status.conditions[?(.type=="Ready")].status`,
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Reason",
+				Type:        "string",
+				Description: "Reason for the capactiy target to not be ready or operational.",
+				JSONPath:    `.status.conditions[?(.status=="False")].message`,
+			},
+			apiextensionv1beta1.CustomResourceColumnDefinition{
+				Name:        "Age",
+				Type:        "date",
+				Description: "The capactiy target's age.",
+				JSONPath:    ".metadata.creationTimestamp",
+			},
+		},
 	},
 }

--- a/pkg/util/clusterstatus/conditions.go
+++ b/pkg/util/clusterstatus/conditions.go
@@ -1,6 +1,8 @@
 package clusterstatus
 
 import (
+	"fmt"
+
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -21,7 +23,7 @@ func IsClusterTrafficReady(conditions []shipper.ClusterTrafficCondition) bool {
 	return readyCond.Status == corev1.ConditionTrue
 }
 
-func IsClusterCapacityReady(conditions []shipper.ClusterCapacityCondition) bool {
+func IsClusterCapacityReady(conditions []shipper.ClusterCapacityCondition) (bool, string) {
 	var readyCond shipper.ClusterCapacityCondition
 	for _, c := range conditions {
 		if c.Type == shipper.ClusterConditionTypeReady {
@@ -30,7 +32,17 @@ func IsClusterCapacityReady(conditions []shipper.ClusterCapacityCondition) bool 
 		}
 	}
 
-	return readyCond.Status == corev1.ConditionTrue
+	if readyCond.Status != corev1.ConditionTrue {
+		msg := readyCond.Reason
+
+		if readyCond.Message != "" {
+			msg = fmt.Sprintf("%s %s", msg, readyCond.Message)
+		}
+
+		return false, msg
+	}
+
+	return true, ""
 }
 
 func IsClusterInstallationReady(conditions []shipper.ClusterInstallationCondition) bool {


### PR DESCRIPTION
This looks like it doesn't change anything in the Release, but that's mostly because the Release was just reading the CapacityTarget conditions anyway :)

Before this, the capacity controller would only put a list of unready
clusters in the CapacityTarget's Ready condition when it would set it to
False. This requires users to go digging into each cluster condition,
and most likely they would only be directed to SadPods, where they could
finally get some useful information.

Now, that information is summarized in a very brief format, in the hopes
that users will have to do less jumping around when investigating why
their CapacityTarget is not progressing.

For instance, if the CapacityTarget is stuck because one container can't
pull its image, we'll now have the following in the CapacityTarget's
.stauts.conditions:

```
[
  {
    "lastTransitionTime": "2020-02-12T13:16:44Z",
    "status": "True",
    "type": "Operational"
  },
  {
    "lastTransitionTime": "2020-02-12T13:16:44Z",
    "message": "docker-desktop: PodsNotReady 3/3: 3x\"test-nginx\" containers with [ImagePullBackOff]",
    "reason": "ClustersNotReady",
    "status": "False",
    "type": "Ready"
  }
]
```

As a bonus, this is also shown on a `kubectl get ct`:

```
% kubectl get ct  snowflake-db84be2b-0
NAME                   OPERATIONAL   READY   REASON                                                                                AGE
snowflake-db84be2b-0   True          False   docker-desktop: PodsNotReady 3/3: 3x"test-nginx" containers with [ImagePullBackOff]   8d
```
This addresses the CT part of both #139 and #79.