### PR TITLE
Clustrerclientstore embeds shipper clientset and informer factory refs #276

### DIFF
--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -273,17 +273,17 @@ func NewClusterConfigurator(clusterConfiguration *config.ClusterConfiguration, k
 		return nil, err
 	}
 
-	clientset, err := client.NewKubeClient(restConfig, AgentName, nil)
+	clientset, err := client.NewKubeClient(AgentName, restConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	shipperClient, err := client.NewShipperClient(restConfig, AgentName, nil)
+	shipperClient, err := client.NewShipperClient(AgentName, restConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	apiExtensionClient, err := client.NewApiExtensionClient(restConfig, AgentName, nil)
+	apiExtensionClient, err := client.NewApiExtensionClient(AgentName, restConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/repo/catalog_test.go
+++ b/pkg/chart/repo/catalog_test.go
@@ -91,7 +91,7 @@ func TestCreateRepoIfNotExist(t *testing.T) {
 			if (err == nil && testCase.err != nil) ||
 				(err != nil && testCase.err == nil) ||
 				(err != nil && err.Error() != testCase.err.Error()) {
-				t.Fatalf("Unexpected error on calling NewCatalog: %q, want: %q", err, testCase.err)
+				t.Fatalf("Unexpected error on calling NewCatalog(): got: %q, want: %q", err, testCase.err)
 			}
 		})
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"runtime"
-	"time"
 
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -15,7 +14,8 @@ import (
 
 const MainAgent = "shipper"
 
-func buildConfig(config rest.Config, ua string, timeout *time.Duration) *rest.Config {
+func decorateConfig(config *rest.Config, ua string) *rest.Config {
+	cp := rest.CopyConfig(config)
 	// NOTE(btyler): These are deliberately high: we're reasonably certain the
 	// API servers can handle a much larger number of requests, and we want to
 	// have better sensitivity to any shifts in API call efficiency (as well as
@@ -23,35 +23,31 @@ func buildConfig(config rest.Config, ua string, timeout *time.Duration) *rest.Co
 	// turn this back down once we've got some metrics on where our current ratio
 	// of shipper objects to API calls is and we start working towards optimizing
 	// that ratio.
-	config.QPS = rest.DefaultQPS * 30
-	config.Burst = rest.DefaultBurst * 30
-
-	if timeout != nil {
-		config.Timeout = *timeout
-	}
+	cp.QPS = rest.DefaultQPS * 30
+	cp.Burst = rest.DefaultBurst * 30
 
 	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-	config.UserAgent = fmt.Sprintf("%s/%s (%s) %s", MainAgent, version.Version, platform, ua)
+	cp.UserAgent = fmt.Sprintf("%s/%s (%s) %s", MainAgent, version.Version, platform, ua)
 
-	return &config
+	return cp
 }
 
-func NewKubeClient(c *rest.Config, ua string, timeout *time.Duration) (*kubernetes.Clientset, error) {
-	return kubernetes.NewForConfig(buildConfig(*c, ua, timeout))
+func NewKubeClient(ua string, config *rest.Config) (*kubernetes.Clientset, error) {
+	return kubernetes.NewForConfig(decorateConfig(config, ua))
 }
 
-func NewKubeClientOrDie(c *rest.Config, ua string, timeout *time.Duration) *kubernetes.Clientset {
-	return kubernetes.NewForConfigOrDie(buildConfig(*c, ua, timeout))
+func NewKubeClientOrDie(ua string, config *rest.Config) *kubernetes.Clientset {
+	return kubernetes.NewForConfigOrDie(decorateConfig(config, ua))
 }
 
-func NewShipperClient(c *rest.Config, ua string, timeout *time.Duration) (*shipperclientset.Clientset, error) {
-	return shipperclientset.NewForConfig(buildConfig(*c, ua, timeout))
+func NewShipperClient(ua string, config *rest.Config) (*shipperclientset.Clientset, error) {
+	return shipperclientset.NewForConfig(decorateConfig(config, ua))
 }
 
-func NewShipperClientOrDie(c *rest.Config, ua string, timeout *time.Duration) *shipperclientset.Clientset {
-	return shipperclientset.NewForConfigOrDie(buildConfig(*c, ua, timeout))
+func NewShipperClientOrDie(ua string, config *rest.Config) *shipperclientset.Clientset {
+	return shipperclientset.NewForConfigOrDie(decorateConfig(config, ua))
 }
 
-func NewApiExtensionClient(c *rest.Config, ua string, timeout *time.Duration) (*apiextensionclientset.Clientset, error) {
-	return apiextensionclientset.NewForConfig(buildConfig(*c, ua, timeout))
+func NewApiExtensionClient(ua string, config *rest.Config) (*apiextensionclientset.Clientset, error) {
+	return apiextensionclientset.NewForConfig(decorateConfig(config, ua))
 }

--- a/pkg/clusterclientstore/cache/server.go
+++ b/pkg/clusterclientstore/cache/server.go
@@ -2,15 +2,15 @@ package cache
 
 type CacheServer interface {
 	Serve()
-	Store(*cluster)
-	Fetch(string) (*cluster, bool)
+	Store(*Cluster)
+	Fetch(string) (*Cluster, bool)
 	Remove(string)
 	Count() int
 	Stop()
 }
 
 type server struct {
-	clusters map[string]*cluster
+	clusters map[string]*Cluster
 	ch       ch
 }
 
@@ -18,9 +18,9 @@ type ch struct {
 	stop chan struct{}
 
 	request  chan string
-	response chan *cluster
+	response chan *Cluster
 
-	store  chan *cluster
+	store  chan *Cluster
 	remove chan string
 
 	countReq chan struct{}
@@ -29,14 +29,14 @@ type ch struct {
 
 func NewServer() *server {
 	return &server{
-		clusters: map[string]*cluster{},
+		clusters: map[string]*Cluster{},
 		ch: ch{
 			stop: make(chan struct{}),
 
 			request:  make(chan string),
-			response: make(chan *cluster),
+			response: make(chan *Cluster),
 
-			store:  make(chan *cluster),
+			store:  make(chan *Cluster),
 			remove: make(chan string),
 
 			countReq: make(chan struct{}),
@@ -87,11 +87,11 @@ func (s *server) Serve() {
 	}
 }
 
-func (s *server) Store(new *cluster) {
+func (s *server) Store(new *Cluster) {
 	s.ch.store <- new
 }
 
-func (s *server) Fetch(clusterName string) (*cluster, bool) {
+func (s *server) Fetch(clusterName string) (*Cluster, bool) {
 	s.ch.request <- clusterName
 	cluster := <-s.ch.response
 	return cluster, cluster != nil

--- a/pkg/clusterclientstore/cache/server_test.go
+++ b/pkg/clusterclientstore/cache/server_test.go
@@ -147,7 +147,7 @@ func TestReplacement(t *testing.T) {
 	}
 }
 
-func newCluster(name string) *cluster {
+func newCluster(name string) *Cluster {
 	kubeClient := kubefake.NewSimpleClientset()
 
 	const noResyncPeriod time.Duration = 0

--- a/pkg/clusterclientstore/interface.go
+++ b/pkg/clusterclientstore/interface.go
@@ -4,12 +4,24 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	shipperclientset "github.com/bookingcom/shipper/pkg/client/clientset/versioned"
+	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
 )
 
 type Interface interface {
 	AddEventHandlerCallback(EventHandlerRegisterFunc)
 	AddSubscriptionCallback(SubscriptionRegisterFunc)
-	GetClient(clusterName string, ua string) (kubernetes.Interface, error)
-	GetConfig(clusterName string) (*rest.Config, error)
-	GetInformerFactory(string) (kubeinformers.SharedInformerFactory, error)
+
+	GetApplicationClusterClientset(clusterName, ua string) (ClientsetInterface, error)
+}
+
+type ClientsetInterface interface {
+	GetConfig() *rest.Config
+
+	GetKubeClient() kubernetes.Interface
+	GetKubeInformerFactory() kubeinformers.SharedInformerFactory
+
+	GetShipperClient() shipperclientset.Interface
+	GetShipperInformerFactory() shipperinformers.SharedInformerFactory
 }

--- a/pkg/clusterclientstore/store_test.go
+++ b/pkg/clusterclientstore/store_test.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/client-go/rest"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperclient "github.com/bookingcom/shipper/pkg/client"
+	shipperclientset "github.com/bookingcom/shipper/pkg/client/clientset/versioned"
 	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
@@ -280,8 +282,11 @@ func (f *fixture) newStore() (*Store, kubeinformers.SharedInformerFactory, shipp
 		func(_ string, _ string, config *rest.Config) (kubernetes.Interface, error) {
 			return kubernetes.NewForConfig(config)
 		},
+		func(_, userAgent string, config *rest.Config) (shipperclientset.Interface, error) {
+			return shipperclient.NewShipperClient(userAgent, config)
+		},
 		kubeInformerFactory.Core().V1().Secrets(),
-		shipperInformerFactory.Shipper().V1alpha1().Clusters(),
+		shipperInformerFactory,
 		shipper.ShipperNamespace,
 		f.restTimeout,
 	)

--- a/pkg/controller/installation/installation_controller_test.go
+++ b/pkg/controller/installation/installation_controller_test.go
@@ -218,8 +218,8 @@ func assertClusterObjects(
 func runController(f *shippertesting.ControllerTestFixture) {
 	controller := NewController(
 		f.ShipperClient,
-		f.ShipperInformerFactory,
 		f.ClusterClientStore,
+		f.ShipperInformerFactory,
 		f.DynamicClientBuilder,
 		localFetchChart,
 		f.Recorder,

--- a/pkg/controller/janitor/janitor_controller.go
+++ b/pkg/controller/janitor/janitor_controller.go
@@ -253,9 +253,13 @@ func (c *Controller) syncAnchor(item *AnchorWorkItem) error {
 }
 
 func (c *Controller) removeAnchor(clusterName string, namespace string, name string) (bool, error) {
-	if client, err := c.clusterClientStore.GetClient(clusterName, AgentName); err != nil {
+	clientset, err := c.clusterClientStore.GetApplicationClusterClientset(clusterName, AgentName)
+	if err != nil {
 		return false, err
-	} else if err := client.CoreV1().ConfigMaps(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+	}
+	client := clientset.GetKubeClient()
+	err = client.CoreV1().ConfigMaps(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
 		return false, shippererrors.NewKubeclientDeleteError(namespace, name, err).
 			WithCoreV1Kind("ConfigMap")
 	} else if err == nil {

--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -23,6 +23,7 @@ import (
 	shipperclient "github.com/bookingcom/shipper/pkg/client/clientset/versioned"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
 	shipperlisters "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
+	"github.com/bookingcom/shipper/pkg/clusterclientstore"
 	"github.com/bookingcom/shipper/pkg/controller"
 	shippercontroller "github.com/bookingcom/shipper/pkg/controller"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
@@ -47,6 +48,7 @@ const (
 // strategy.
 type Controller struct {
 	clientset shipperclient.Interface
+	store     clusterclientstore.Interface
 
 	applicationLister  shipperlisters.ApplicationLister
 	applicationsSynced cache.InformerSynced
@@ -91,6 +93,7 @@ type ReleaseStrategyStateTransition struct {
 
 func NewController(
 	clientset shipperclient.Interface,
+	store clusterclientstore.Interface,
 	informerFactory shipperinformers.SharedInformerFactory,
 	chartFetcher shipperrepo.ChartFetcher,
 	recorder record.EventRecorder,
@@ -108,6 +111,7 @@ func NewController(
 
 	controller := &Controller{
 		clientset: clientset,
+		store:     store,
 
 		applicationLister:  applicationInformer.Lister(),
 		applicationsSynced: applicationInformer.Informer().HasSynced,

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -145,6 +145,7 @@ type fixture struct {
 	cycles          int
 	objects         []runtime.Object
 	clientset       *shipperfake.Clientset
+	store           *shippertesting.FakeClusterClientStore
 	informerFactory shipperinformers.SharedInformerFactory
 	recorder        *record.FakeRecorder
 
@@ -223,6 +224,7 @@ func (f *fixture) run() {
 func (f *fixture) newController() *Controller {
 	return NewController(
 		f.clientset,
+		f.store,
 		f.informerFactory,
 		localFetchChart,
 		f.recorder,


### PR DESCRIPTION
This commit changes the signature of clusterclientstore interface and
    arms it with `GetApplicationClusterClientset/2` method which returns an
    instance of `clusterclientstore.ClientsetInterface`. The new composite
    interface is supposed to embed kubernetes and shipper clientsets and
    informer factories. The aforementioned method is the one that can return
    an error, which is opposite to the former `clusterclientset.Interface`
    behavior where every independent method call to `GetConfig/1`,
    `GetClient/1` and `GetInformerFactory/1` could return an error
    independently, leaving the client with a responsibility if it's ok to
    proceed forward.

Fixes #276