### PR TITLE
Fixed inconsistency in historical release strategy state conditions

### DIFF
--- a/pkg/apis/shipper/v1alpha1/types.go
+++ b/pkg/apis/shipper/v1alpha1/types.go
@@ -466,9 +466,9 @@ type ReleaseStrategyCondition struct {
 	Type               StrategyConditionType  `json:"type"`
 	Status             corev1.ConditionStatus `json:"status"`
 	LastTransitionTime metav1.Time            `json:"lastTransitionTime,omitempty"`
-	Reason             string                 `json:"reason,omitempty"`
-	Message            string                 `json:"message,omitempty"`
-	Step               int32                  `json:"step,omitempty"`
+	Reason             string                 `json:"reason"`
+	Message            string                 `json:"message"`
+	Step               int32                  `json:"step"`
 }
 
 type StrategyConditionType string

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -295,6 +296,8 @@ func (f *fixture) buildIncumbent(namespace string, relName string, replicaCount 
 		f.t.Fatalf("The fixture is missing at least 1 Cluster object")
 	}
 
+	step, stepName := int32(2), "full on"
+
 	rolloutblocksOverrides := app.Annotations[shipper.RolloutBlocksOverrideAnnotation]
 	rel := &shipper.Release{
 		TypeMeta: metav1.TypeMeta{
@@ -324,8 +327,8 @@ func (f *fixture) buildIncumbent(namespace string, relName string, replicaCount 
 		},
 		Status: shipper.ReleaseStatus{
 			AchievedStep: &shipper.AchievedStep{
-				Step: 2,
-				Name: "full on",
+				Step: step,
+				Name: stepName,
 			},
 			Conditions: []shipper.ReleaseCondition{
 				{Type: shipper.ReleaseConditionTypeBlocked, Status: corev1.ConditionFalse},
@@ -333,10 +336,34 @@ func (f *fixture) buildIncumbent(namespace string, relName string, replicaCount 
 				{Type: shipper.ReleaseConditionTypeScheduled, Status: corev1.ConditionTrue},
 				{Type: shipper.ReleaseConditionTypeStrategyExecuted, Status: corev1.ConditionTrue},
 			},
-			Strategy: &shipper.ReleaseStrategyStatus{},
+			Strategy: &shipper.ReleaseStrategyStatus{
+				State: shipper.ReleaseStrategyState{
+					WaitingForInstallation: shipper.StrategyStateFalse,
+					WaitingForTraffic:      shipper.StrategyStateFalse,
+					WaitingForCapacity:     shipper.StrategyStateFalse,
+					WaitingForCommand:      shipper.StrategyStateFalse,
+				},
+				Conditions: []shipper.ReleaseStrategyCondition{
+					{
+						Type:   shipper.StrategyConditionContenderAchievedCapacity,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+					{
+						Type:   shipper.StrategyConditionContenderAchievedInstallation,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+					{
+						Type:   shipper.StrategyConditionContenderAchievedTraffic,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+				},
+			},
 		},
 		Spec: shipper.ReleaseSpec{
-			TargetStep: 2,
+			TargetStep: step,
 			Environment: shipper.ReleaseEnvironment{
 				Strategy: &vanguard,
 				Chart: shipper.Chart{
@@ -996,7 +1023,7 @@ func (f *fixture) expectCapacityStatusPatch(step int32, ct *shipper.CapacityTarg
 		"status": shipper.ReleaseStatus{
 			Strategy: &shipper.ReleaseStrategyStatus{
 				Conditions: strategyConditions.AsReleaseStrategyConditions(),
-				State:      strategyConditions.AsReleaseStrategyState(step, true, false),
+				State:      strategyConditions.AsReleaseStrategyState(step, true, false, true),
 			},
 		},
 	}
@@ -1095,7 +1122,7 @@ func (f *fixture) expectTrafficStatusPatch(step int32, tt *shipper.TrafficTarget
 		"status": shipper.ReleaseStatus{
 			Strategy: &shipper.ReleaseStrategyStatus{
 				Conditions: strategyConditions.AsReleaseStrategyConditions(),
-				State:      strategyConditions.AsReleaseStrategyState(step, true, false),
+				State:      strategyConditions.AsReleaseStrategyState(step, true, false, true),
 			},
 		},
 	}
@@ -1470,6 +1497,7 @@ func TestContenderReleasePhaseIsWaitingForCommandForInitialStepState(t *testing.
 	incumbentName, contenderName := "test-incumbent", "test-contender"
 	app.Status.History = []string{incumbentName, contenderName}
 	f := newFixture(t, app.DeepCopy(), cluster.DeepCopy())
+	f.cycles = 1
 
 	totalReplicaCount := int32(10)
 	incumbent := f.buildIncumbent(namespace, incumbentName, totalReplicaCount)
@@ -3051,6 +3079,137 @@ func TestControllerDetectInconsistentTargetStep(t *testing.T) {
 	f.expectedEvents = append(f.expectedEvents,
 		fmt.Sprintf("Normal ReleaseConditionChanged [StrategyExecuted True] -> [StrategyExecuted False StrategyExecutionFailed failed to execute strategy: \"Release test-namespace/test-incumbent target step is inconsistent: unexpected value 1 (expected: 2)\"]"),
 	)
+
+	f.run()
+}
+
+// This test ensures we review historical release strategy conditions
+func TestUpdatesHistoricalReleaseStrategyStateConditions(t *testing.T) {
+	namespace := "test-namespace"
+	app := buildApplication(namespace, "test-app")
+	totalReplicaCount := int32(4)
+
+	cluster := buildCluster("minikube")
+	f := newFixture(t, app.DeepCopy(), cluster.DeepCopy())
+
+	step := int32(2)
+
+	// we are not interested in all updates happening in the loop and we expect
+	// the first one to update the very first release in the chain.
+	f.cycles = 1
+
+	// we instantiate 3 releases: in this case the first one will be left out of
+	// the "extended" (contender-incumbent) strategy executor loop and reviewed
+	// with a reduced amount of ensurer steps
+	relinfos := []*releaseInfo{
+		f.buildIncumbent(namespace, "pre-incumbent", totalReplicaCount),
+		f.buildIncumbent(namespace, "incumbent", totalReplicaCount),
+		// we create a full-on release intentionally, therefore we use
+		// buildIncumbent helper
+		f.buildContender(namespace, "contender", totalReplicaCount),
+	}
+
+	// make sure generation-sorted releases preserve the original order
+	for i, relinfo := range relinfos {
+		relinfo.release.ObjectMeta.Annotations[shipper.ReleaseGenerationAnnotation] = strconv.Itoa(i)
+	}
+
+	relinfos[0].capacityTarget.Spec.Clusters = []shipper.ClusterCapacityTarget{
+		{
+			Name:              cluster.Name,
+			Percent:           0,
+			TotalReplicaCount: totalReplicaCount,
+		},
+	}
+	relinfos[0].trafficTarget.Spec.Clusters = []shipper.ClusterTrafficTarget{
+		{
+			Name:   cluster.Name,
+			Weight: 0,
+		},
+	}
+
+	relinfos[2].capacityTarget.Spec.Clusters = []shipper.ClusterCapacityTarget{
+		{
+			Name:              cluster.Name,
+			Percent:           1,
+			TotalReplicaCount: totalReplicaCount,
+		},
+	}
+
+	// we intenitonally set one of the strategy conditions to an unready state
+	// and expect it to get fixed by the controller
+	preincumbent := relinfos[0].release
+	cond := conditions.NewStrategyConditions(preincumbent.Status.Strategy.Conditions...)
+	cond.SetFalse(
+		shipper.StrategyConditionContenderAchievedCapacity,
+		conditions.StrategyConditionsUpdate{
+			Reason: ClustersNotReady,
+			// this message is incomplete but it doesn't matter in the context
+			// of this test
+			Message: fmt.Sprintf("release %q hasn't achieved capacity in clusters: %s",
+				preincumbent.Name, cluster.Name),
+			Step:               step,
+			LastTransitionTime: time.Now(),
+		},
+	)
+	preincumbent.Status.Strategy = &shipper.ReleaseStrategyStatus{
+		Conditions: cond.AsReleaseStrategyConditions(),
+		State:      cond.AsReleaseStrategyState(step, false, true, false),
+	}
+
+	for _, relinfo := range relinfos {
+		f.addObjects(
+			relinfo.release.DeepCopy(),
+			relinfo.installationTarget.DeepCopy(),
+			relinfo.capacityTarget.DeepCopy(),
+			relinfo.trafficTarget.DeepCopy(),
+		)
+	}
+
+	expectedStatus := map[string]interface{}{
+		"status": shipper.ReleaseStatus{
+			Strategy: &shipper.ReleaseStrategyStatus{
+				State: shipper.ReleaseStrategyState{
+					WaitingForInstallation: shipper.StrategyStateFalse,
+					WaitingForCommand:      shipper.StrategyStateFalse,
+					WaitingForTraffic:      shipper.StrategyStateFalse,
+					WaitingForCapacity:     shipper.StrategyStateFalse,
+				},
+				Conditions: []shipper.ReleaseStrategyCondition{
+					shipper.ReleaseStrategyCondition{
+						Type:   shipper.StrategyConditionContenderAchievedCapacity,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+					shipper.ReleaseStrategyCondition{
+						Type:   shipper.StrategyConditionContenderAchievedInstallation,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+					shipper.ReleaseStrategyCondition{
+						Type:   shipper.StrategyConditionContenderAchievedTraffic,
+						Status: corev1.ConditionTrue,
+						Step:   step,
+					},
+				},
+			},
+		},
+	}
+	patch, _ := json.Marshal(expectedStatus)
+	f.actions = append(f.actions, kubetesting.NewPatchAction(
+		shipper.SchemeGroupVersion.WithResource("releases"),
+		preincumbent.GetNamespace(),
+		preincumbent.GetName(),
+		types.MergePatchType,
+		patch,
+	))
+
+	key := fmt.Sprintf("%s/%s", preincumbent.GetNamespace(), preincumbent.GetName())
+
+	f.expectedEvents = append(f.expectedEvents,
+		fmt.Sprintf(
+			"Normal ReleaseStateTransitioned Release %q had its state \"WaitingForCapacity\" transitioned to \"False\"",
+			key))
 
 	f.run()
 }

--- a/pkg/util/conditions/strategy.go
+++ b/pkg/util/conditions/strategy.go
@@ -134,6 +134,7 @@ func (sc StrategyConditionsMap) AsReleaseStrategyState(
 	step int32,
 	hasIncumbent bool,
 	isLastStep bool,
+	isHead bool,
 ) shipper.ReleaseStrategyState {
 
 	// States we don't know just yet are set to Unknown
@@ -209,6 +210,7 @@ func (sc StrategyConditionsMap) AsReleaseStrategyState(
 	}
 
 	waitingForCommandFlag := !isLastStep &&
+		isHead &&
 		!waitingForCapacity &&
 		!waitingForTraffic &&
 		achievedInstallation

--- a/pkg/util/conditions/strategy_test.go
+++ b/pkg/util/conditions/strategy_test.go
@@ -236,7 +236,7 @@ func TestContenderStateWaitingForCapacity(t *testing.T) {
 		WaitingForCommand:      shipper.StrategyStateFalse,
 	}
 
-	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false)
+	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false, true)
 	if !reflect.DeepEqual(releaseStrategyState, expected) {
 		t.Fatalf(
 			"Strategy states are different\nDiff:\n %s",
@@ -283,7 +283,7 @@ func TestContenderStateWaitingForTraffic(t *testing.T) {
 		WaitingForCommand:      shipper.StrategyStateFalse,
 	}
 
-	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false)
+	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false, true)
 	if !reflect.DeepEqual(releaseStrategyState, expected) {
 		t.Fatalf(
 			"Strategy states are different\nDiff:\n %s",
@@ -329,7 +329,7 @@ func TestIncumbentStateWaitingForTraffic(t *testing.T) {
 		WaitingForCommand:      shipper.StrategyStateFalse,
 	}
 
-	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false)
+	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false, true)
 	if !reflect.DeepEqual(releaseStrategyState, expected) {
 		t.Fatalf(
 			"Strategy states are different\nDiff:\n %s",
@@ -375,7 +375,7 @@ func TestIncumbentStateWaitingForCapacity(t *testing.T) {
 		WaitingForCommand:      shipper.StrategyStateFalse,
 	}
 
-	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false)
+	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false, true)
 	if !reflect.DeepEqual(releaseStrategyState, expected) {
 		t.Fatalf(
 			"Strategy states are different\nDiff:\n %s",
@@ -420,7 +420,7 @@ func TestStateWaitingForCommand(t *testing.T) {
 		WaitingForCommand:      shipper.StrategyStateTrue,
 	}
 
-	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false)
+	releaseStrategyState := sc.AsReleaseStrategyState(step1, true, false, true)
 	if !reflect.DeepEqual(releaseStrategyState, expected) {
 		t.Fatalf(
 			"Strategy states are different\nDiff:\n %s",


### PR DESCRIPTION
This commit fixes release status strategy condition inconsistency
reported in #299. The issue boils down to the way strategy executor
handles historical release: it only runs against traffic and capacity
ensurers and updates the release strategy state if it looks incomplete.
Under a positive scenario branch, an update never happens, causing
strategy conditions to stall in mistakenly broken state.

This commit strategy executor behavior slightly. In particular, all
releases except contender are forced to look ahead only. The prior
implementation was not strict on this behavior and all releases kept
reporting their incumbent state along with their own state. A contender
is the only release in the chain that is looking behind at it's
contender. This implies on a more deterministic strategy state and
conditions buildup: non-contender releases drop any information about
incumbent's state in their conditions, only remaining the information
about the owning release's state. The motivation behind this move is to
reduce the number of oscillations in the release chain by eliminating
simultaneous look-ahead and look-behind actions. In fact, there is no
use in non-contender release's incumbent state: the only essential
transition is happening between incumbent and contender.

Apart from this change, the commit includes a series of bug fixes. It
introduces a minor change in shipper v1alpha1 types
`ReleaseStrategyCondition` definition: attributes `Reason`, `Message`
and `Step` have dropped `omitempty` flag. This fixes the problem when
conditions remained in an inconsistent state where status was indicating
a healthy state but the reason and the message attributes were present.
This behavior can be explained by the combination of `omitempty` k8s
strategic merge patch usage. When an attribute is set to a zero-value
(https://dave.cheney.net/2013/01/19/what-is-the-zero-value-and-why-is-it-useful)
`json.Marshal` omits these values causing k8s strategic merge strategy
to merge old non-empty attributes of a structure (like: `Reason`, `Step`) with
updated ones (like: `Status`). Explicit no-omitempty behavior forces json to
encode empty values in patches and fixes this inconsistency.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>