### PR TITLE
[WIP] Shipperctl installs management and application CRDs independently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install: install-shipper
 install-shipper: install-shipper-app install-shipper-mgmt
 
 install-shipper-app: build/shipper-app.image.$(IMAGE_TAG) build/shipper-app.deployment.$(IMAGE_TAG).yaml
-	$(KUBECTL) apply -f build/shipper-app.deployment.$(IMAGE_TAG).yaml
+	$(KUBECTL) --context $(SHIPPER_CLUSTER) apply -f build/shipper-app.deployment.$(IMAGE_TAG).yaml
 
 install-shipper-mgmt: build/shipper-mgmt.image.$(IMAGE_TAG) build/shipper-mgmt.deployment.$(IMAGE_TAG).yaml
 	$(KUBECTL) apply -f build/shipper-mgmt.deployment.$(IMAGE_TAG).yaml

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -9,6 +9,7 @@ make setup
 make -j e2e \
 	TEST_HELM_REPO_URL=${TEST_HELM_REPO_URL:=https://raw.githubusercontent.com/bookingcom/shipper/${TRAVIS_COMMIT}/test/e2e/testdata} \
 	DOCKER_REGISTRY=${DOCKER_REGISTRY:=registry:5000} \
+	SHIPPER_CLUSTER=kind-app \
 	E2E_FLAGS="--test.v"
 
 TEST_STATUS=$?
@@ -18,8 +19,17 @@ TEST_STATUS=$?
 rm -f build/*.latest.yaml
 
 # Output all of the logs from the shipper pods, for reference
-kubectl -n shipper-system logs $(kubectl -n shipper-system get pod -l component=shipper-app -o jsonpath='{.items[0].metadata.name}')
-kubectl -n shipper-system logs $(kubectl -n shipper-system get pod -l component=shipper-mgmt -o jsonpath='{.items[0].metadata.name}')
+echo "========================== Management cluster logs ============================"
+kubectl -n shipper-system logs \
+	$(kubectl -n shipper-system get pod -l component=shipper-mgmt -o jsonpath='{.items[0].metadata.name}')
+
+echo "========================== Application cluster logs ==========================="
+# It's a shortcut: we hardcode a single app cluster. If we end up running e2e
+# tests on multiple app clusters, this should be ran for each of them.
+kubectl --context kind-app -n shipper-system get deployment shipper-app -o yaml
+kubectl --context kind-app -n shipper-system get replicaset -l component=shipper-app -o yaml
+kubectl --context kind-app -n shipper-system logs \
+	$(kubectl --context kind-app -n shipper-system get pod -l component=shipper-app -o jsonpath='{.items[0].metadata.name}')
 
 # Exit with the exit code we got from the e2e tests
 exit $TEST_STATUS

--- a/cmd/shipperctl/cmd/clusters.go
+++ b/cmd/shipperctl/cmd/clusters.go
@@ -152,7 +152,7 @@ func runJoinClustersCommand(cmd *cobra.Command, args []string) error {
 }
 
 func setupManagementCluster(cmd *cobra.Command, configurator *configurator.Cluster) error {
-	if err := createOrUpdateCrds(cmd, configurator); err != nil {
+	if err := createOrUpdateManagementCrds(cmd, configurator); err != nil {
 		return err
 	}
 
@@ -192,6 +192,10 @@ func setupManagementCluster(cmd *cobra.Command, configurator *configurator.Clust
 }
 
 func setupApplicationCluster(cmd *cobra.Command, configurator *configurator.Cluster) error {
+	if err := createOrUpdateApplicationCrds(cmd, configurator); err != nil {
+		return err
+	}
+
 	if err := createNamespace(cmd, configurator); err != nil {
 		return err
 	}
@@ -236,8 +240,8 @@ func joinClusters(
 	return nil
 }
 
-func createOrUpdateCrds(cmd *cobra.Command, configurator *configurator.Cluster) error {
-	cmd.Print("Registering or updating custom resource definitions... ")
+func createOrUpdateManagementCrds(cmd *cobra.Command, configurator *configurator.Cluster) error {
+	cmd.Print("Registering or updating management bundle of custom resource definitions... ")
 	if err := configurator.CreateOrUpdateCRD(crds.Application); err != nil {
 		return err
 	}
@@ -245,6 +249,22 @@ func createOrUpdateCrds(cmd *cobra.Command, configurator *configurator.Cluster) 
 	if err := configurator.CreateOrUpdateCRD(crds.Release); err != nil {
 		return err
 	}
+
+	if err := configurator.CreateOrUpdateCRD(crds.Cluster); err != nil {
+		return err
+	}
+
+	if err := configurator.CreateOrUpdateCRD(crds.RolloutBlock); err != nil {
+		return err
+	}
+
+	cmd.Println("done")
+
+	return nil
+}
+
+func createOrUpdateApplicationCrds(cmd *cobra.Command, configurator *configurator.Cluster) error {
+	cmd.Print("Registering or updating application bundle of custom resource definitions... ")
 
 	if err := configurator.CreateOrUpdateCRD(crds.InstallationTarget); err != nil {
 		return err
@@ -255,14 +275,6 @@ func createOrUpdateCrds(cmd *cobra.Command, configurator *configurator.Cluster) 
 	}
 
 	if err := configurator.CreateOrUpdateCRD(crds.TrafficTarget); err != nil {
-		return err
-	}
-
-	if err := configurator.CreateOrUpdateCRD(crds.Cluster); err != nil {
-		return err
-	}
-
-	if err := configurator.CreateOrUpdateCRD(crds.RolloutBlock); err != nil {
 		return err
 	}
 

--- a/kubernetes/shipper-app.deployment.yaml
+++ b/kubernetes/shipper-app.deployment.yaml
@@ -35,4 +35,4 @@ spec:
         ports:
         - name: metrics
           containerPort: 8889
-      serviceAccountName: shipper-management-cluster
+      serviceAccountName: shipper-application-cluster


### PR DESCRIPTION
Up until now, shipper has been installing CRD objects to management
clusters only and this was a part of `shipperctl clusters setup
management` command. As we're splitting shipper in management and
application components, these components need their own CRDs to
operate on the relevant cluster.

Therefore, an updated list of CRD groups:
* Management
  - Application
  - Release
  - Cluster
  - RolloutBlock
* Application
  - InstallationTarget
  - CapacityTarget
  - TrafficTarget

Folow-up to: https://github.com/bookingcom/shipper/pull/292

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>