### PR TITLE
Fixed targetStep in the example release.yaml

### DIFF
--- a/docs/examples/release.yaml
+++ b/docs/examples/release.yaml
@@ -3,7 +3,7 @@ kind: Release
 metadata:
   name: reviews-api-deadbeef-1
 spec:
-  targetStep: 0
+  targetStep: 2
   environment:
     chart:
       name: reviews-api


### PR DESCRIPTION
The example release object used in the high-level API overview defines
spec.targetStep as 0 and status.achievedState as 2, whereas
status.strategy.state declares all 4 state attributes (installation,
traffic, capacity and command) as False, which indicates that the
release is complete. This might be misleading for a reader as this
release state is unstable and immediately provokes a chain of changes by
Shipper. Declaring targetStep as 2 makes more sense as this brings the
release to a "happy" complete state and the rest of the conditions and
state attributes make sense.

Signed-off-by: Oleg Sidorov <oleg.sidorov@booking.com>