### PR TITLE
Condition Complete False for non-fullon releases

### DIFF
--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -581,6 +581,14 @@ func (c *Controller) executeReleaseStrategyForCluster(
 				"",
 			)
 			diff.Append(releaseutil.SetReleaseCondition(&rel.Status, *condition))
+		} else {
+			condition := releaseutil.NewReleaseCondition(
+				shipper.ReleaseConditionTypeComplete,
+				corev1.ConditionFalse,
+				"",
+				"",
+			)
+			diff.Append(releaseutil.SetReleaseCondition(&rel.Status, *condition))
 		}
 	}
 


### PR DESCRIPTION
Once release reaches full on, it gets a condition Complete True. If we step back this release (to vanguard, for example), this release should not have a condition Complete True.