### PR TITLE
Fix Shipperctl Clusters Parameters

### DIFF
--- a/cmd/shipperctl/cmd/clusters.go
+++ b/cmd/shipperctl/cmd/clusters.go
@@ -78,6 +78,7 @@ const (
 )
 
 func init() {
+	// Flags common to all commands under `shipperctl clusters`
 	for _, cmd := range []*cobra.Command{joinCmd, setupMgmtCmd, setupAppCmd} {
 		cmd.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
 		if err := cmd.MarkFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
@@ -86,12 +87,15 @@ func init() {
 
 		cmd.Flags().StringVarP(&shipperNamespace, "namespace", "n", shipper.ShipperNamespace, "the namespace where Shipper is running")
 		cmd.Flags().StringVar(&managementClusterContext, "management-cluster-context", "", "the name of the context to use to communicate with the management cluster. defaults to the current one")
-		cmd.Flags().StringVarP(&globalRolloutBlockNamespace, "rollout-blocks-global-namespace", "g", shipper.GlobalRolloutBlockNamespace, "the namespace where global RolloutBlocks should be created")
-		cmd.Flags().StringVar(&managementClusterServiceAccount, "management-cluster-service-account", shipper.ShipperManagementServiceAccount, "the name of the service account Shipper will use for the management cluster")
-		cmd.Flags().StringVar(&applicationClusterServiceAccount, "application-cluster-service-account", shipper.ShipperApplicationServiceAccount, "the name of the service account Shipper will use for the application cluster")
 	}
 
-	joinCmd.Flags().StringVarP(&clustersYaml, fileFlagName, "f", "clusters.yaml", "the path to an YAML file containing application cluster configuration")
+	setupMgmtCmd.Flags().StringVarP(&globalRolloutBlockNamespace, "rollout-blocks-global-namespace", "g", shipper.GlobalRolloutBlockNamespace, "the namespace where global RolloutBlocks should be created")
+	setupMgmtCmd.Flags().StringVar(&managementClusterServiceAccount, "management-cluster-service-account", shipper.ShipperManagementServiceAccount, "the name of the service account Shipper will use in the management cluster")
+
+	setupAppCmd.Flags().StringVar(&applicationClusterServiceAccount, "application-cluster-service-account", shipper.ShipperApplicationServiceAccount, "the name of the service account Shipper will use for the application cluster")
+
+	joinCmd.Flags().StringVar(&applicationClusterServiceAccount, "application-cluster-service-account", shipper.ShipperApplicationServiceAccount, "the name of the service account Shipper will use for the application cluster")
+	joinCmd.Flags().StringVarP(&clustersYaml, fileFlagName, "f", "clusters.yaml", "the path to a YAML file containing application cluster configuration")
 	err := joinCmd.MarkFlagFilename(fileFlagName, "yaml")
 	if err != nil {
 		joinCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", fileFlagName, err)


### PR DESCRIPTION
Previously, these commands were accepting parameters they didn't need
(e.g. `shipperctl clusters setup management` was asking for
`--application-cluster-service-account`). This PR fixes those
parameters, so that each command only asks for what it needs.


----

#