### PR TITLE
Shipper-app metrics

### DIFF
--- a/cmd/shipper-mgmt/main.go
+++ b/cmd/shipper-mgmt/main.go
@@ -79,7 +79,7 @@ type metricsCfg struct {
 	wqMetrics    *shippermetrics.PrometheusWorkqueueProvider
 	restLatency  *shippermetrics.RESTLatencyMetric
 	restResult   *shippermetrics.RESTResultMetric
-	stateMetrics statemetrics.Metrics
+	stateMetrics statemetrics.MgmtMetrics
 }
 
 type cfg struct {
@@ -179,7 +179,7 @@ func main() {
 		stopCh,
 	)
 
-	ssm := statemetrics.Metrics{
+	ssm := statemetrics.MgmtMetrics{
 		AppsLister:     shipperInformerFactory.Shipper().V1alpha1().Applications().Lister(),
 		RelsLister:     shipperInformerFactory.Shipper().V1alpha1().Releases().Lister(),
 		ClustersLister: shipperInformerFactory.Shipper().V1alpha1().Clusters().Lister(),

--- a/pkg/metrics/state/app-state.go
+++ b/pkg/metrics/state/app-state.go
@@ -1,0 +1,142 @@
+package state
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	kubelisters "k8s.io/client-go/listers/core/v1"
+	klog "k8s.io/klog"
+
+	shipperlisters "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
+)
+
+var (
+	itsDesc = prometheus.NewDesc(
+		fqn("installationtargets"),
+		"Number of InstallationTarget objects",
+		[]string{"namespace"},
+		nil,
+	)
+
+	ctsDesc = prometheus.NewDesc(
+		fqn("capacitytargets"),
+		"Number of CapacityTarget objects",
+		[]string{"namespace"},
+		nil,
+	)
+
+	ttsDesc = prometheus.NewDesc(
+		fqn("traffictargets"),
+		"Number of TrafficTarget objects",
+		[]string{"namespace"},
+		nil,
+	)
+)
+
+type AppMetrics struct {
+	ItsLister shipperlisters.InstallationTargetLister
+	CtsLister shipperlisters.CapacityTargetLister
+	TtsLister shipperlisters.TrafficTargetLister
+
+	NssLister kubelisters.NamespaceLister
+}
+
+func (ssm AppMetrics) Collect(ch chan<- prometheus.Metric) {
+	ssm.collectInstallationTargets(ch)
+	ssm.collectCapacityTargets(ch)
+	ssm.collectTrafficTargets(ch)
+}
+
+func (ssm AppMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- itsDesc
+	ch <- ctsDesc
+	ch <- ttsDesc
+}
+
+func (ssm AppMetrics) collectInstallationTargets(ch chan<- prometheus.Metric) {
+	nss, err := getNamespaces(ssm.NssLister)
+	if err != nil {
+		klog.Warningf("collect Namespaces: %s", err)
+		return
+	}
+
+	its, err := ssm.ItsLister.List(everything)
+	if err != nil {
+		klog.Warningf("collect InstallationTargets: %s", err)
+		return
+	}
+
+	itsPerNamespace := make(map[string]float64)
+	for _, it := range its {
+		itsPerNamespace[it.Namespace]++
+	}
+
+	klog.V(4).Infof("its: %v", itsPerNamespace)
+
+	for _, ns := range nss {
+		n, ok := itsPerNamespace[ns.Name]
+		if !ok {
+			n = 0
+		}
+
+		ch <- prometheus.MustNewConstMetric(itsDesc, prometheus.GaugeValue, n, ns.Name)
+	}
+}
+
+func (ssm AppMetrics) collectCapacityTargets(ch chan<- prometheus.Metric) {
+	nss, err := getNamespaces(ssm.NssLister)
+	if err != nil {
+		klog.Warningf("collect Namespaces: %s", err)
+		return
+	}
+
+	cts, err := ssm.CtsLister.List(everything)
+	if err != nil {
+		klog.Warningf("collect CapacityTargets: %s", err)
+		return
+	}
+
+	ctsPerNamespace := make(map[string]float64)
+	for _, it := range cts {
+		ctsPerNamespace[it.Namespace]++
+	}
+
+	klog.V(4).Infof("cts: %v", ctsPerNamespace)
+
+	for _, ns := range nss {
+		n, ok := ctsPerNamespace[ns.Name]
+		if !ok {
+			n = 0
+		}
+
+		ch <- prometheus.MustNewConstMetric(ctsDesc, prometheus.GaugeValue, n, ns.Name)
+	}
+}
+
+func (ssm AppMetrics) collectTrafficTargets(ch chan<- prometheus.Metric) {
+	nss, err := getNamespaces(ssm.NssLister)
+	if err != nil {
+		klog.Warningf("collect Namespaces: %s", err)
+		return
+	}
+
+	tts, err := ssm.TtsLister.List(everything)
+	if err != nil {
+		klog.Warningf("collect TrafficTargets: %s", err)
+		return
+	}
+
+	ttsPerNamespace := make(map[string]float64)
+	for _, it := range tts {
+		ttsPerNamespace[it.Namespace]++
+	}
+
+	klog.V(4).Infof("tts: %v", ttsPerNamespace)
+
+	for _, ns := range nss {
+		n, ok := ttsPerNamespace[ns.Name]
+		if !ok {
+			n = 0
+		}
+
+		ch <- prometheus.MustNewConstMetric(ttsDesc, prometheus.GaugeValue, n, ns.Name)
+	}
+}

--- a/pkg/metrics/state/mgmt-state.go
+++ b/pkg/metrics/state/mgmt-state.go
@@ -61,7 +61,7 @@ var (
 
 var everything = labels.Everything()
 
-type Metrics struct {
+type MgmtMetrics struct {
 	AppsLister     shipperlisters.ApplicationLister
 	RelsLister     shipperlisters.ReleaseLister
 	ClustersLister shipperlisters.ClusterLister
@@ -75,21 +75,21 @@ type Metrics struct {
 	ReleaseDurationBuckets []float64
 }
 
-func (ssm Metrics) Collect(ch chan<- prometheus.Metric) {
+func (ssm MgmtMetrics) Collect(ch chan<- prometheus.Metric) {
 	ssm.collectApplications(ch)
 	ssm.collectReleases(ch)
 	ssm.collectClusters(ch)
 	ssm.collectRolloutBlocks(ch)
 }
 
-func (ssm Metrics) Describe(ch chan<- *prometheus.Desc) {
+func (ssm MgmtMetrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- appsDesc
 	ch <- relsDesc
 	ch <- clustersDesc
 	ch <- rolloutblocksDesc
 }
 
-func (ssm Metrics) collectApplications(ch chan<- prometheus.Metric) {
+func (ssm MgmtMetrics) collectApplications(ch chan<- prometheus.Metric) {
 	nss, err := getNamespaces(ssm.NssLister)
 	if err != nil {
 		klog.Warningf("collect Namespaces: %s", err)
@@ -119,7 +119,7 @@ func (ssm Metrics) collectApplications(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (ssm Metrics) collectReleases(ch chan<- prometheus.Metric) {
+func (ssm MgmtMetrics) collectReleases(ch chan<- prometheus.Metric) {
 	rels, err := ssm.RelsLister.List(everything)
 	if err != nil {
 		klog.Warningf("collect Releases: %s", err)
@@ -191,7 +191,7 @@ func (ssm Metrics) collectReleases(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (ssm Metrics) collectClusters(ch chan<- prometheus.Metric) {
+func (ssm MgmtMetrics) collectClusters(ch chan<- prometheus.Metric) {
 	clusters, err := ssm.ClustersLister.List(everything)
 	if err != nil {
 		klog.Warningf("collect Clusters: %s", err)
@@ -215,7 +215,7 @@ func (ssm Metrics) collectClusters(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (ssm Metrics) collectRolloutBlocks(ch chan<- prometheus.Metric) {
+func (ssm MgmtMetrics) collectRolloutBlocks(ch chan<- prometheus.Metric) {
 	nss, err := getNamespaces(ssm.NssLister)
 	if err != nil {
 		klog.Errorf("collect Namespaces: %s", err)


### PR DESCRIPTION
After splitting shipper and uniting shipper-state-metrics with shipper-mgmt, we lose state metrics from target controllers, who now live in shipper-app.
This adds state metrics collection to shipper-app, so we can collect the same metrics we collected before the split.