### PR TITLE
Collect metrics for all Release conditions

### DIFF
--- a/pkg/metrics/state/mgmt-state.go
+++ b/pkg/metrics/state/mgmt-state.go
@@ -136,6 +136,8 @@ func (ssm MgmtMetrics) collectReleases(ch chan<- prometheus.Metric) {
 	conditions := []shipper.ReleaseConditionType{
 		shipper.ReleaseConditionTypeComplete,
 		shipper.ReleaseConditionTypeBlocked,
+		shipper.ReleaseConditionTypeClustersChosen,
+		shipper.ReleaseConditionTypeStrategyExecuted,
 	}
 
 	for _, rel := range rels {


### PR DESCRIPTION
Part of splitting shipper was changing the conditions we set to Releases. This change makes sure we collect metrics for the new conditions as well.