### PR TITLE
Reject modifications to Release environment

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -283,8 +283,14 @@ func (c *Webhook) validateRelease(request *admission.AdmissionRequest, release s
 			return err
 		}
 
+		// validate against rollout blocks
 		if !reflect.DeepEqual(release.Spec, oldRelease.Spec) {
 			err = rolloutblock.ValidateBlocks(existingBlocks, overrides)
+		}
+
+		// make sure the environment wasn't changed
+		if !reflect.DeepEqual(release.Spec.Environment, oldRelease.Spec.Environment) {
+			return fmt.Errorf("the Release environment must not be changed; consider editing the Application object")
 		}
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -153,6 +153,55 @@ func TestNewAppAllIn(t *testing.T) {
 	f.checkReadyPods(relName, targetReplicas)
 }
 
+func TestRejectModificationToReleaseEnv(t *testing.T) {
+	if !*runEndToEnd {
+		t.Skip("skipping end-to-end tests: --e2e is false")
+	}
+	t.Parallel()
+
+	targetReplicas := 4
+	ns, err := setupNamespace(t.Name())
+	if err != nil {
+		t.Fatalf("could not create namespace %s: %q", t.Name(), err)
+	}
+	f := newFixture(ns.GetName(), t)
+	defer func() {
+		if *inspectFailed && t.Failed() {
+			return
+		}
+		teardownNamespace(ns.GetName())
+	}()
+
+	newApp := newApplication(ns.GetName(), appName, &allIn)
+	newApp.Spec.Template.Values = shipper.ChartValues{"replicaCount": targetReplicas}
+	newApp.Spec.Template.Chart.Name = "test-nginx"
+	newApp.Spec.Template.Chart.Version = "0.0.1"
+
+	_, err = shipperClient.ShipperV1alpha1().Applications(ns.GetName()).Create(newApp)
+	if err != nil {
+		t.Fatalf("could not create application %q: %q", appName, err)
+	}
+
+	t.Logf("waiting for a new release for new application %q", appName)
+	rel := f.waitForRelease(appName, 0)
+	relName := rel.GetName()
+	t.Logf("waiting for release %q to complete", relName)
+	f.waitForComplete(rel.GetName())
+	t.Logf("checking that release %q has %d pods (strategy step 0 -- finished)", relName, targetReplicas)
+	f.checkReadyPods(relName, targetReplicas)
+
+	rel, err = shipperClient.ShipperV1alpha1().Releases(ns.GetName()).Get(relName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get release %q: %q", relName, err)
+	}
+	rel.Spec.Environment.Chart.Name = "changed name"
+	_, err = shipperClient.ShipperV1alpha1().Releases(ns.GetName()).Update(rel)
+	if err == nil {
+		t.Fatalf("updated release environment %q: %q", relName, err)
+	}
+	t.Logf("successfully failed to update release environment %q", relName)
+}
+
 func TestNewAppAllInWithRolloutBlockOverride(t *testing.T) {
 	if !*runEndToEnd {
 		t.Skip("skipping end-to-end tests: --e2e is false")


### PR DESCRIPTION
A Release should be created only by modifying the Application object. That should be the only way for a user to create a new Release to roll out.
Older Release objects should never be modified. They are there so that a user can use them as a reference when reverting to an earlier release.