### PR TITLE
Fixes for release 0.9

### DIFF
--- a/pkg/controller/janitor/janitor_controller.go
+++ b/pkg/controller/janitor/janitor_controller.go
@@ -2,7 +2,6 @@ package janitor
 
 import (
 	"fmt"
-	"sort"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +21,7 @@ import (
 	shipperlisters "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
 	"github.com/bookingcom/shipper/pkg/clusterclientstore"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
+	"github.com/bookingcom/shipper/pkg/util/filters"
 	objectutil "github.com/bookingcom/shipper/pkg/util/object"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
 	shipperworkqueue "github.com/bookingcom/shipper/pkg/workqueue"
@@ -204,8 +204,9 @@ func (c *Controller) syncHandler(key string) error {
 		selectedClusters := releaseutil.GetSelectedClusters(rel)
 
 		for _, cluster := range clusters {
-			n := sort.SearchStrings(selectedClusters, cluster.Name)
-			if n > 0 {
+			clusterSelected := filters.SliceContainsString(selectedClusters, cluster.Name)
+			// garbage collect only of this cluster is *not* chosen
+			if !clusterSelected {
 				clustersToGarbageCollect = append(clustersToGarbageCollect, cluster.Name)
 			}
 		}

--- a/pkg/controller/release/migration.go
+++ b/pkg/controller/release/migration.go
@@ -124,7 +124,7 @@ func (c *Controller) migrateCapacityTargets(relName, namespace string, selector 
 		initialCt.Labels[shipper.MigrationLabel] = "true"
 		_, err = c.clientset.ShipperV1alpha1().CapacityTargets(namespace).Update(initialCt)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("error updating initial capacity target %v", err)
 			ctErrors.Append(err)
 		}
 	}
@@ -221,7 +221,7 @@ func (c *Controller) migrateTrafficTargets(relName, namespace string, selector l
 		initialTt.Labels[shipper.MigrationLabel] = "true"
 		_, err = c.clientset.ShipperV1alpha1().TrafficTargets(namespace).Update(initialTt)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("error updating initial traffic target %v", err)
 			ttErrors.Append(err)
 		}
 	}
@@ -315,7 +315,7 @@ func (c *Controller) migrateInstallationTargets(relName, namespace string, selec
 		initialIt.Labels[shipper.MigrationLabel] = "true"
 		_, err = c.clientset.ShipperV1alpha1().InstallationTargets(namespace).Update(initialIt)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("error updating initial installation target %v", err)
 			itErrors.Append(err)
 		}
 	}

--- a/pkg/controller/release/migration.go
+++ b/pkg/controller/release/migration.go
@@ -17,19 +17,16 @@ func (c *Controller) migrateTargetObjects(relName, namespace string) error {
 	migrationErrors := shippererrors.NewMultiError()
 	err := c.migrateCapacityTargets(relName, namespace, selector)
 	if err != nil {
-		//return err
 		migrationErrors.Append(err)
 	}
 
 	err = c.migrateTrafficTargets(relName, namespace, selector)
 	if err != nil {
-		//return err
 		migrationErrors.Append(err)
 	}
 
 	err = c.migrateInstallationTargets(relName, namespace, selector)
 	if err != nil {
-		//return err
 		migrationErrors.Append(err)
 	}
 
@@ -87,14 +84,9 @@ func (c *Controller) migrateCapacityTargets(relName, namespace string, selector 
 	shouldTag := false
 	// put in application clusters:
 	for _, cluster := range initialCt.Spec.Clusters {
-		//if decommissioned cluster => skip!!!
-		if cluster.Name == "kind-app-d" {
-			continue
-		}
 		clusterName := cluster.Name
 		clusterClientsets, err := c.store.GetApplicationClusterClientset(clusterName, AgentName)
 		if err != nil {
-			//return err
 			ctErrors.Append(err)
 			continue
 		}
@@ -105,14 +97,12 @@ func (c *Controller) migrateCapacityTargets(relName, namespace string, selector 
 		}
 
 		if !errors.IsAlreadyExists(err) {
-			//return err
 			ctErrors.Append(err)
 			continue
 		}
 		// checking if existing object was migrated already
 		capacityTarget, err := clusterClientsets.GetShipperClient().ShipperV1alpha1().CapacityTargets(ct.Namespace).Get(ct.Name, metav1.GetOptions{})
 		if err != nil {
-			//return err
 			ctErrors.Append(err)
 			continue
 		}
@@ -127,7 +117,6 @@ func (c *Controller) migrateCapacityTargets(relName, namespace string, selector 
 		_, err = clusterClientsets.GetShipperClient().ShipperV1alpha1().CapacityTargets(ct.Namespace).Update(ct)
 		if err != nil {
 			ctErrors.Append(err)
-			//return err
 		}
 	}
 	if ctErrors.Flatten() == nil && shouldTag {
@@ -136,7 +125,6 @@ func (c *Controller) migrateCapacityTargets(relName, namespace string, selector 
 		_, err = c.clientset.ShipperV1alpha1().CapacityTargets(namespace).Update(initialCt)
 		if err != nil {
 			klog.Error(err)
-			//return err
 			ctErrors.Append(err)
 		}
 	}
@@ -193,14 +181,9 @@ func (c *Controller) migrateTrafficTargets(relName, namespace string, selector l
 	shouldTag := false
 	// put in application clusters:
 	for _, cluster := range initialTt.Spec.Clusters {
-		//if decommissioned cluster => skip!!!
-		if cluster.Name == "kind-app-d" {
-			continue
-		}
 		clusterName := cluster.Name
 		clusterClientsets, err := c.store.GetApplicationClusterClientset(clusterName, AgentName)
 		if err != nil {
-			//return err
 			ttErrors.Append(err)
 			continue
 		}
@@ -211,14 +194,12 @@ func (c *Controller) migrateTrafficTargets(relName, namespace string, selector l
 		}
 
 		if !errors.IsAlreadyExists(err) {
-			//return err
 			ttErrors.Append(err)
 			continue
 		}
 		// checking if existing object was migrated already
 		trafficTarget, err := clusterClientsets.GetShipperClient().ShipperV1alpha1().TrafficTargets(tt.Namespace).Get(tt.Name, metav1.GetOptions{})
 		if err != nil {
-			//return err
 			ttErrors.Append(err)
 			continue
 		}
@@ -232,7 +213,6 @@ func (c *Controller) migrateTrafficTargets(relName, namespace string, selector l
 		tt.Labels[shipper.MigrationLabel] = "true"
 		_, err = clusterClientsets.GetShipperClient().ShipperV1alpha1().TrafficTargets(tt.Namespace).Update(tt)
 		if err != nil {
-			//return err
 			ttErrors.Append(err)
 		}
 	}
@@ -242,7 +222,6 @@ func (c *Controller) migrateTrafficTargets(relName, namespace string, selector l
 		_, err = c.clientset.ShipperV1alpha1().TrafficTargets(namespace).Update(initialTt)
 		if err != nil {
 			klog.Error(err)
-			//return err
 			ttErrors.Append(err)
 		}
 	}
@@ -298,13 +277,8 @@ func (c *Controller) migrateInstallationTargets(relName, namespace string, selec
 	shouldTag := false
 	// put in application clusters:
 	for _, clusterName := range initialIt.Spec.Clusters {
-		//if decommissioned cluster => skip!!!
-		if clusterName == "kind-app-d" {
-			continue
-		}
 		clusterClientsets, err := c.store.GetApplicationClusterClientset(clusterName, AgentName)
 		if err != nil {
-			//return err
 			itErrors.Append(err)
 			continue
 		}
@@ -315,14 +289,12 @@ func (c *Controller) migrateInstallationTargets(relName, namespace string, selec
 		}
 
 		if !errors.IsAlreadyExists(err) {
-			//return err
 			itErrors.Append(err)
 			continue
 		}
 		// checking if existing object was migrated already
 		installationTarget, err := clusterClientsets.GetShipperClient().ShipperV1alpha1().InstallationTargets(it.Namespace).Get(it.Name, metav1.GetOptions{})
 		if err != nil {
-			//return err
 			itErrors.Append(err)
 			continue
 		}
@@ -335,7 +307,6 @@ func (c *Controller) migrateInstallationTargets(relName, namespace string, selec
 		it.Labels[shipper.MigrationLabel] = "true"
 		_, err = clusterClientsets.GetShipperClient().ShipperV1alpha1().InstallationTargets(it.Namespace).Update(it)
 		if err != nil {
-			//return err
 			itErrors.Append(err)
 		}
 	}
@@ -345,7 +316,6 @@ func (c *Controller) migrateInstallationTargets(relName, namespace string, selec
 		_, err = c.clientset.ShipperV1alpha1().InstallationTargets(namespace).Update(initialIt)
 		if err != nil {
 			klog.Error(err)
-			//return err
 			itErrors.Append(err)
 		}
 	}

--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -342,6 +342,7 @@ func (c *Controller) processRelease(rel *shipper.Release) (*shipper.Release, err
 
 	err = c.migrateTargetObjects(rel.Name, rel.Namespace)
 	if err != nil {
+		klog.Warningf("error migrating release %s : %v", rel.Name, err)
 		releaseStrategyExecutedCond := releaseutil.NewReleaseCondition(
 			shipper.ReleaseConditionTypeStrategyExecuted,
 			corev1.ConditionFalse,

--- a/pkg/util/filters/filters.go
+++ b/pkg/util/filters/filters.go
@@ -30,3 +30,12 @@ func BelongsToApp(obj interface{}) bool {
 
 	return ok
 }
+
+func SliceContainsString(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fix the migration code to not bail out on the first error. The migration code should collect errors on the way. This will help it deal with non-panic errors such as decommissioned cluster better. Making sure the migration code does not try and fail to update an initial target object for a dev cluster.

Fix wrong garbage collection. `SearchStrings` will return the index of the object in the array if found, or the index to insert this object of not found.
It will return 0 if the item is located in index 0 in the array, and it will never return -1.
As we would like to remove orphaned objects for Releases where they are *not* scheduled, we need a better way to check if this cluster is selected.