### PR TITLE
Shipperctl commands to help with decommissioned clusters

### DIFF
--- a/cmd/shipperctl/cmd/clean.go
+++ b/cmd/shipperctl/cmd/clean.go
@@ -24,8 +24,8 @@ var (
 		Short: "clean Shipper objects",
 	}
 
-	cleanRelCmd = &cobra.Command{
-		Use:   "releases",
+	cleanDeadClustersCmd = &cobra.Command{
+		Use:   "decommissioned-clusters",
 		Short: "clean Shipper releases from decommissioned clusters",
 		RunE:  runCleanCommand,
 	}
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	// Flags common to all commands under `shipperctl clusters`
-	for _, cmd := range []*cobra.Command{countReleasesCmd, countContendersCmd, cleanRelCmd} {
+	for _, cmd := range []*cobra.Command{countReleasesCmd, countContendersCmd, cleanDeadClustersCmd} {
 		cmd.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
 		if err := cmd.MarkFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
 			cmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
@@ -60,7 +60,7 @@ func init() {
 		cmd.Flags().StringSliceVar(&decommissionedClusters, "decommissionedClusters", decommissionedClusters, "list of decommissioned clusters")
 	}
 
-	CleanCmd.AddCommand(cleanRelCmd)
+	CleanCmd.AddCommand(cleanDeadClustersCmd)
 	CountCmd.AddCommand(countContendersCmd)
 	CountCmd.AddCommand(countReleasesCmd)
 }

--- a/cmd/shipperctl/cmd/clean.go
+++ b/cmd/shipperctl/cmd/clean.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/bookingcom/shipper/cmd/shipperctl/configurator"
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	apputil "github.com/bookingcom/shipper/pkg/util/application"
+	"github.com/bookingcom/shipper/pkg/util/filters"
+	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
+)
+
+var (
+	decommissionedClusters []string
+
+	CleanCmd = &cobra.Command{
+		Use:   "clean",
+		Short: "clean Shipper objects",
+	}
+
+	cleanRelCmd = &cobra.Command{
+		Use:   "releases",
+		Short: "clean Shipper releases from decommissioned clusters",
+		RunE:  runCleanCommand,
+	}
+
+	CountCmd = &cobra.Command{
+		Use:   "count",
+		Short: "count Shipper releases that are scheduled *only* on decommissioned clusters",
+	}
+
+	countContendersCmd = &cobra.Command{
+		Use:   "contender",
+		Short: "count Shipper *contenders* that are scheduled *only* on decommissioned clusters",
+		RunE:  runCountContenderCommand,
+	}
+
+	countReleasesCmd = &cobra.Command{
+		Use:   "release",
+		Short: "count Shipper *releases* that are scheduled *only* on decommissioned clusters",
+		RunE:  runCountReleasesCommand,
+	}
+)
+
+func init() {
+	// Flags common to all commands under `shipperctl clusters`
+	for _, cmd := range []*cobra.Command{countReleasesCmd, countContendersCmd, cleanRelCmd} {
+		cmd.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
+		if err := cmd.MarkFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
+			cmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
+		}
+
+		cmd.Flags().StringVar(&managementClusterContext, "management-cluster-context", "", "the name of the context to use to communicate with the management cluster. defaults to the current one")
+		cmd.Flags().StringSliceVar(&decommissionedClusters, "decommissionedClusters", decommissionedClusters, "list of decommissioned clusters")
+	}
+
+	CleanCmd.AddCommand(cleanRelCmd)
+	CountCmd.AddCommand(countContendersCmd)
+	CountCmd.AddCommand(countReleasesCmd)
+}
+
+func runCleanCommand(cmd *cobra.Command, args []string) error {
+	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+	for _, ns := range namespaceList.Items {
+		releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+		for _, rel := range releaseList.Items {
+			trueClusters := getFilteredSelectedClusters(rel)
+			if len(trueClusters) > 0 {
+				sort.Strings(trueClusters)
+
+				if strings.Join(trueClusters, ",") == rel.Annotations[shipper.ReleaseClustersAnnotation] {
+					cmd.Printf("skipping release %s/%s\n", rel.Namespace, rel.Name)
+					continue
+				}
+				rel.Annotations[shipper.ReleaseClustersAnnotation] = strings.Join(trueClusters, ",")
+				cmd.Printf("Editing annotations of release %s/%s to %s...", rel.Namespace, rel.Name, rel.Annotations[shipper.ReleaseClustersAnnotation])
+				_, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Update(&rel)
+				if err != nil {
+					errList = append(errList, err.Error())
+				}
+				cmd.Println("done")
+				continue
+			}
+			isContender, err := isContender(rel, configurator)
+			if err != nil {
+				errList = append(errList, err.Error())
+				continue
+			}
+			if len(trueClusters) == 0 && !isContender {
+				cmd.Printf("Deleting release %s/%s...", rel.Namespace, rel.Name)
+				err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Delete(rel.Name, &metav1.DeleteOptions{})
+				if err != nil {
+					errList = append(errList, err.Error())
+				}
+				cmd.Println("done")
+			}
+		}
+	}
+
+	if len(errList) > 0 {
+		return fmt.Errorf(strings.Join(errList, ","))
+	}
+	return nil
+}
+
+func runCountContenderCommand(cmd *cobra.Command, args []string) error {
+	counter := 0
+	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+	for _, ns := range namespaceList.Items {
+		applicationList, err := configurator.ShipperClient.ShipperV1alpha1().Applications(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+		for _, app := range applicationList.Items {
+			contender, err := getContender(app, configurator)
+			if err != nil {
+				errList = append(errList, err.Error())
+				continue
+			}
+			trueClusters := getFilteredSelectedClusters(*contender)
+			if len(trueClusters) == 0 {
+				counter++
+			}
+		}
+	}
+
+	cmd.Println("Number of *contenders* that are scheduled only on decommissioned clusters: ", counter)
+	if len(errList) > 0 {
+		return fmt.Errorf(strings.Join(errList, ","))
+	}
+	return nil
+}
+
+func runCountReleasesCommand(cmd *cobra.Command, args []string) error {
+	counter := 0
+
+	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+	for _, ns := range namespaceList.Items {
+		releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+		for _, rel := range releaseList.Items {
+			trueClusters := getFilteredSelectedClusters(rel)
+			if len(trueClusters) == 0 {
+				counter++
+			}
+		}
+	}
+
+	cmd.Println("Number of *releases* that are scheduled only on decommissioned clusters: ", counter)
+	if len(errList) > 0 {
+		return fmt.Errorf(strings.Join(errList, ","))
+	}
+	return nil
+}
+
+func getFilteredSelectedClusters(rel shipper.Release) []string {
+	clusters := releaseutil.GetSelectedClusters(&rel)
+	var trueClusters []string
+	for _, cluster := range clusters {
+		if !filters.SliceContainsString(decommissionedClusters, cluster) {
+			trueClusters = append(trueClusters, cluster)
+		}
+	}
+	return trueClusters
+}
+
+func isContender(rel shipper.Release, configurator *configurator.Cluster) (bool, error) {
+	appName := rel.Labels[shipper.AppLabel]
+	app, err := configurator.ShipperClient.ShipperV1alpha1().Applications(rel.Namespace).Get(appName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	contender, err := getContender(*app, configurator)
+	if err != nil {
+		return false, err
+	}
+	return contender.Name == rel.Name && contender.Namespace == rel.Namespace, nil
+}
+
+func getContender(app shipper.Application, configurator *configurator.Cluster) (*shipper.Release, error) {
+	appName := app.Name
+	selector := labels.Set{shipper.AppLabel: appName}.AsSelector()
+	releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(app.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	var rels []*shipper.Release
+	for _, rel := range releaseList.Items {
+		rels = append(rels, &rel)
+	}
+	rels = releaseutil.SortByGenerationDescending(rels)
+	contender, err := apputil.GetContender(appName, rels)
+	if err != nil {
+		return nil, err
+	}
+	return contender, nil
+}

--- a/cmd/shipperctl/cmd/decommission.go
+++ b/cmd/shipperctl/cmd/decommission.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	decommissionedClusters []string
+	dryrun                 bool
 
 	CleanCmd = &cobra.Command{
 		Use:   "clean",
@@ -56,6 +57,7 @@ func init() {
 			command.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
 		}
 
+		command.Flags().BoolVar(&dryrun, "dryrun", false, "if true, only prints the objects that will be modifies/deleted")
 		command.Flags().StringVar(&managementClusterContext, "management-cluster-context", "", "the name of the context to use to communicate with the management cluster. defaults to the current one")
 		command.Flags().StringSliceVar(&decommissionedClusters, "decommissionedClusters", decommissionedClusters, "list of decommissioned clusters")
 	}
@@ -83,7 +85,7 @@ func runCleanCommand(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		for _, rel := range releaseList.Items {
-			trueClusters := getFilteredSelectedClusters(rel)
+			trueClusters := getFilteredSelectedClusters(&rel)
 			if len(trueClusters) > 0 {
 				sort.Strings(trueClusters)
 
@@ -93,25 +95,33 @@ func runCleanCommand(cmd *cobra.Command, args []string) error {
 				}
 				rel.Annotations[shipper.ReleaseClustersAnnotation] = strings.Join(trueClusters, ",")
 				cmd.Printf("Editing annotations of release %s/%s to %s...", rel.Namespace, rel.Name, rel.Annotations[shipper.ReleaseClustersAnnotation])
-				_, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Update(&rel)
-				if err != nil {
-					errList = append(errList, err.Error())
+				if !dryrun {
+					_, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Update(&rel)
+					if err != nil {
+						errList = append(errList, err.Error())
+					}
+					cmd.Println("done")
+				} else {
+					cmd.Println("dryrun")
 				}
-				cmd.Println("done")
 				continue
 			}
-			isContender, err := isContender(rel, configurator)
+			isContender, err := isContender(&rel, configurator)
 			if err != nil {
 				errList = append(errList, err.Error())
 				continue
 			}
 			if len(trueClusters) == 0 && !isContender {
 				cmd.Printf("Deleting release %s/%s...", rel.Namespace, rel.Name)
-				err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Delete(rel.Name, &metav1.DeleteOptions{})
-				if err != nil {
-					errList = append(errList, err.Error())
+				if !dryrun {
+					err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).Delete(rel.Name, &metav1.DeleteOptions{})
+					if err != nil {
+						errList = append(errList, err.Error())
+					}
+					cmd.Println("done")
+				} else {
+					cmd.Println("dryrun")
 				}
-				cmd.Println("done")
 			}
 		}
 	}
@@ -141,12 +151,12 @@ func runCountContenderCommand(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		for _, app := range applicationList.Items {
-			contender, err := getContender(app, configurator)
+			contender, err := getContender(&app, configurator)
 			if err != nil {
 				errList = append(errList, err.Error())
 				continue
 			}
-			trueClusters := getFilteredSelectedClusters(*contender)
+			trueClusters := getFilteredSelectedClusters(contender)
 			if len(trueClusters) == 0 {
 				counter++
 			}
@@ -180,7 +190,7 @@ func runCountReleasesCommand(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		for _, rel := range releaseList.Items {
-			trueClusters := getFilteredSelectedClusters(rel)
+			trueClusters := getFilteredSelectedClusters(&rel)
 			if len(trueClusters) == 0 {
 				counter++
 			}
@@ -194,8 +204,8 @@ func runCountReleasesCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getFilteredSelectedClusters(rel shipper.Release) []string {
-	clusters := releaseutil.GetSelectedClusters(&rel)
+func getFilteredSelectedClusters(rel *shipper.Release) []string {
+	clusters := releaseutil.GetSelectedClusters(rel)
 	var trueClusters []string
 	for _, cluster := range clusters {
 		if !filters.SliceContainsString(decommissionedClusters, cluster) {
@@ -205,29 +215,29 @@ func getFilteredSelectedClusters(rel shipper.Release) []string {
 	return trueClusters
 }
 
-func isContender(rel shipper.Release, configurator *configurator.Cluster) (bool, error) {
+func isContender(rel *shipper.Release, configurator *configurator.Cluster) (bool, error) {
 	appName := rel.Labels[shipper.AppLabel]
 	app, err := configurator.ShipperClient.ShipperV1alpha1().Applications(rel.Namespace).Get(appName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
-	contender, err := getContender(*app, configurator)
+	contender, err := getContender(app, configurator)
 	if err != nil {
 		return false, err
 	}
 	return contender.Name == rel.Name && contender.Namespace == rel.Namespace, nil
 }
 
-func getContender(app shipper.Application, configurator *configurator.Cluster) (*shipper.Release, error) {
+func getContender(app *shipper.Application, configurator *configurator.Cluster) (*shipper.Release, error) {
 	appName := app.Name
 	selector := labels.Set{shipper.AppLabel: appName}.AsSelector()
 	releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(app.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, err
 	}
-	var rels []*shipper.Release
-	for _, rel := range releaseList.Items {
-		rels = append(rels, &rel)
+	rels := make([]*shipper.Release, len(releaseList.Items))
+	for i, _ := range releaseList.Items {
+		rels[i] = &releaseList.Items[i]
 	}
 	rels = releaseutil.SortByGenerationDescending(rels)
 	contender, err := apputil.GetContender(appName, rels)

--- a/cmd/shipperctl/cmd/decommission.go
+++ b/cmd/shipperctl/cmd/decommission.go
@@ -49,15 +49,15 @@ var (
 )
 
 func init() {
-	// Flags common to all commands under `shipperctl clusters`
-	for _, cmd := range []*cobra.Command{countReleasesCmd, countContendersCmd, cleanDeadClustersCmd} {
-		cmd.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
-		if err := cmd.MarkFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
-			cmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
+	// Flags common to all commands under `shipperctl decommission`
+	for _, command := range []*cobra.Command{countReleasesCmd, countContendersCmd, cleanDeadClustersCmd} {
+		command.Flags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
+		if err := command.MarkFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
+			command.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
 		}
 
-		cmd.Flags().StringVar(&managementClusterContext, "management-cluster-context", "", "the name of the context to use to communicate with the management cluster. defaults to the current one")
-		cmd.Flags().StringSliceVar(&decommissionedClusters, "decommissionedClusters", decommissionedClusters, "list of decommissioned clusters")
+		command.Flags().StringVar(&managementClusterContext, "management-cluster-context", "", "the name of the context to use to communicate with the management cluster. defaults to the current one")
+		command.Flags().StringSliceVar(&decommissionedClusters, "decommissionedClusters", decommissionedClusters, "list of decommissioned clusters")
 	}
 
 	CleanCmd.AddCommand(cleanDeadClustersCmd)

--- a/cmd/shipperctl/main.go
+++ b/cmd/shipperctl/main.go
@@ -18,6 +18,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(cmd.ClustersCmd)
+	rootCmd.AddCommand(cmd.CountCmd)
+	rootCmd.AddCommand(cmd.CleanCmd)
 }
 
 func main() {


### PR DESCRIPTION
shipperctl commands to clean decommissioned clusters from release annotation, to help shipper forget about these clusters