### PR TITLE
Enqueue release metric

### DIFF
--- a/cmd/shipper-mgmt/main.go
+++ b/cmd/shipper-mgmt/main.go
@@ -82,6 +82,7 @@ type metricsCfg struct {
 	restLatency  *shippermetrics.RESTLatencyMetric
 	restResult   *shippermetrics.RESTResultMetric
 	certExpire   *shippermetrics.WebhookMetric
+	enqueueRel   *shippermetrics.EnqueueMetric
 	stateMetrics statemetrics.MgmtMetrics
 }
 
@@ -234,6 +235,7 @@ func main() {
 			restLatency:  shippermetrics.NewRESTLatencyMetric(),
 			restResult:   shippermetrics.NewRESTResultMetric(),
 			certExpire:   shippermetrics.NewTLSCertExpireMetric(),
+			enqueueRel:   shippermetrics.NewEnqueueMetric(),
 			stateMetrics: ssm,
 		},
 	}
@@ -263,6 +265,7 @@ func runMetrics(cfg *metricsCfg) {
 	prometheus.MustRegister(cfg.wqMetrics.GetMetrics()...)
 	prometheus.MustRegister(cfg.restLatency.Summary, cfg.restResult.Counter)
 	prometheus.MustRegister(cfg.certExpire.GetMetrics()...)
+	prometheus.MustRegister(cfg.enqueueRel.GetMetrics()...)
 	prometheus.MustRegister(instrumentedclient.GetMetrics()...)
 	prometheus.MustRegister(cfg.stateMetrics)
 
@@ -440,6 +443,7 @@ func startReleaseController(cfg *cfg) (bool, error) {
 		cfg.shipperInformerFactory,
 		cfg.chartFetcher,
 		cfg.recorder(release.AgentName),
+		*cfg.metrics.enqueueRel,
 	)
 
 	cfg.wg.Add(1)

--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -27,6 +27,7 @@ import (
 	shipperlisters "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
 	"github.com/bookingcom/shipper/pkg/clusterclientstore"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
+	shippermetrics "github.com/bookingcom/shipper/pkg/metrics/prometheus"
 	"github.com/bookingcom/shipper/pkg/util/conditions"
 	"github.com/bookingcom/shipper/pkg/util/diff"
 	diffutil "github.com/bookingcom/shipper/pkg/util/diff"
@@ -67,6 +68,8 @@ type Controller struct {
 
 	recorder record.EventRecorder
 
+	enqueueMetric shippermetrics.EnqueueMetric
+
 	trafficTargetLister      shipperlisters.TrafficTargetLister      // Deprecated
 	capacityTargetLister     shipperlisters.CapacityTargetLister     // Deprecated
 	installationTargetLister shipperlisters.InstallationTargetLister // Deprecated
@@ -91,6 +94,7 @@ func NewController(
 	informerFactory shipperinformers.SharedInformerFactory,
 	chartFetcher shipperrepo.ChartFetcher,
 	recorder record.EventRecorder,
+	enqueueMetric shippermetrics.EnqueueMetric,
 ) *Controller {
 
 	releaseInformer := informerFactory.Shipper().V1alpha1().Releases()
@@ -123,6 +127,8 @@ func NewController(
 		chartFetcher: chartFetcher,
 
 		recorder: recorder,
+
+		enqueueMetric: enqueueMetric,
 
 		// Deprecated
 		trafficTargetLister:      trafficTargetInformer.Lister(),
@@ -662,9 +668,12 @@ func (c *Controller) enqueueReleaseAndNeighbours(obj interface{}) {
 	}
 	if predecessor != nil {
 		c.enqueueRelease(predecessor)
+		c.observeEnqueueRelease(rel, predecessor)
+
 	}
 	if ancestor != nil {
 		c.enqueueRelease(ancestor)
+		c.observeEnqueueRelease(rel, ancestor)
 	}
 }
 
@@ -723,7 +732,17 @@ func (c *Controller) enqueueReleaseFromAssociatedObject(obj interface{}) {
 		}
 	}
 
+	c.observeEnqueueRelease(kubeobj, rel)
+
 	c.enqueueReleaseAndNeighbours(rel)
+}
+
+func (c *Controller) observeEnqueueRelease(kubeobj metav1.Object, enqueuedRelease *shipper.Release) {
+	enqueuedReleaseName := enqueuedRelease.Name
+	objKey := objectutil.MetaKey(kubeobj)
+	objKind := objectutil.Kind(kubeobj)
+	klog.Infof("Triggering enqueue on release %s and neighbours from object %s %s", enqueuedReleaseName, objKind, objKey)
+	c.enqueueMetric.ObserveEnqueueRelease(releaseutil.GetSelectedClusters(enqueuedRelease), enqueuedReleaseName, objKey, objKind)
 }
 
 func (c *Controller) getSiblingReleases(rel *shipper.Release) (*shipper.Release, *shipper.Release, error) {

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"fmt"
+	"github.com/bookingcom/shipper/pkg/metrics/prometheus"
 	"strings"
 	"testing"
 	"time"
@@ -504,6 +505,7 @@ func runController(f *shippertesting.ControllerTestFixture) {
 		f.ShipperInformerFactory,
 		shippertesting.LocalFetchChart,
 		f.Recorder,
+		*prometheus.NewEnqueueMetric(),
 	)
 
 	stopCh := make(chan struct{})

--- a/pkg/metrics/prometheus/enqueue.go
+++ b/pkg/metrics/prometheus/enqueue.go
@@ -1,0 +1,47 @@
+package prometheus
+
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+type EnqueueMetric struct {
+	EnqueueRelGauge        *prom.GaugeVec
+	EnqueuePerClusterGauge *prom.GaugeVec
+}
+
+func NewEnqueueMetric() *EnqueueMetric {
+	return &EnqueueMetric{
+		EnqueueRelGauge: prom.NewGaugeVec(
+			prom.GaugeOpts{
+				Namespace: ns,
+				Subsystem: wqSubsys,
+				Name:      "enqueue_release",
+				Help:      "which objects were triggering enqueueing releases",
+			},
+			[]string{"enqueued_release_name", "triggering_object_name", "triggering_object_kind"},
+		),
+		EnqueuePerClusterGauge: prom.NewGaugeVec(
+			prom.GaugeOpts{
+				Namespace: ns,
+				Subsystem: wqSubsys,
+				Name:      "enqueue_release_per_cluster",
+				Help:      "which objects were triggering enqueueing releases per scheduled cluster",
+			},
+			[]string{"enqueued_release_name", "enqueued_release_cluster", "triggering_object_name", "triggering_object_kind"},
+		),
+	}
+}
+
+func (m *EnqueueMetric) ObserveEnqueueRelease(enqueuedReleaseClusters []string, enqueuedReleaseName, triggeringObjectName, triggeringObjectKind string) {
+	m.EnqueueRelGauge.WithLabelValues(enqueuedReleaseName, triggeringObjectName, triggeringObjectKind).Inc()
+	for _, clusterName := range enqueuedReleaseClusters {
+		m.EnqueuePerClusterGauge.WithLabelValues(enqueuedReleaseName, clusterName, triggeringObjectName, triggeringObjectKind).Inc()
+	}
+}
+
+func (m *EnqueueMetric) GetMetrics() []prom.Collector {
+	return []prom.Collector{
+		m.EnqueueRelGauge,
+		m.EnqueuePerClusterGauge,
+	}
+}

--- a/pkg/util/object/kind.go
+++ b/pkg/util/object/kind.go
@@ -1,0 +1,15 @@
+package object
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Kind(object metav1.Object) string {
+	objKind := strings.TrimPrefix(object.GetSelfLink(), "/apis/shipper.booking.com/v1alpha1/namespaces/")
+	objKind = strings.Trim(objKind, object.GetNamespace())
+	objKind = strings.Trim(objKind, object.GetName())
+	objKind = strings.Trim(objKind, "/")
+	return objKind
+}


### PR DESCRIPTION
Counting the objects that are enqueueing releases and the releases we enqueue. This is so we can monitor the behavior of the controllers and see what is triggering enqueueing releases.