### PR TITLE
Enqueue metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,11 @@ setup: $(SHIPPER_CLUSTERS_YAML) build/shipperctl.$(GOOS)-amd64
 # running `make -j e2e` should get you up and running immediately. Do remember
 # do setup your clusters with `make setup` though.
 e2e: install build/e2e.test
+	sleep 5s
+	kubectl --context $(MGMT_KUBE_CONTEXT) -n $(SHIPPER_NAMESPACE) wait --for=condition=Available deploy/shipper-mgmt
+	kubectl --context $(APP_KUBE_CONTEXT) -n $(SHIPPER_NAMESPACE) wait --for=condition=Available deploy/shipper-app
+	kubectl --context $(MGMT_KUBE_CONTEXT) -n $(SHIPPER_NAMESPACE) wait --for=condition=Ready pod --all
+	kubectl --context $(APP_KUBE_CONTEXT) -n $(SHIPPER_NAMESPACE) wait --for=condition=Ready pod --all
 	./build/e2e.test --e2e --kubeconfig ~/.kube/config \
 		--appcluster $(SHIPPER_CLUSTER) \
 		--testcharts $(TEST_HELM_REPO_URL) \

--- a/cmd/shipper-mgmt/main.go
+++ b/cmd/shipper-mgmt/main.go
@@ -82,6 +82,7 @@ type metricsCfg struct {
 	restLatency  *shippermetrics.RESTLatencyMetric
 	restResult   *shippermetrics.RESTResultMetric
 	certExpire   *shippermetrics.WebhookMetric
+	enqueueRel   *shippermetrics.EnqueueMetric
 	stateMetrics statemetrics.MgmtMetrics
 }
 
@@ -234,6 +235,7 @@ func main() {
 			restLatency:  shippermetrics.NewRESTLatencyMetric(),
 			restResult:   shippermetrics.NewRESTResultMetric(),
 			certExpire:   shippermetrics.NewTLSCertExpireMetric(),
+			enqueueRel:   shippermetrics.NewEnqueueMetric(),
 			stateMetrics: ssm,
 		},
 	}
@@ -263,6 +265,7 @@ func runMetrics(cfg *metricsCfg) {
 	prometheus.MustRegister(cfg.wqMetrics.GetMetrics()...)
 	prometheus.MustRegister(cfg.restLatency.Summary, cfg.restResult.Counter)
 	prometheus.MustRegister(cfg.certExpire.GetMetrics()...)
+	prometheus.MustRegister(cfg.enqueueRel.GetMetrics()...)
 	prometheus.MustRegister(instrumentedclient.GetMetrics()...)
 	prometheus.MustRegister(cfg.stateMetrics)
 
@@ -440,6 +443,7 @@ func startReleaseController(cfg *cfg) (bool, error) {
 		cfg.shipperInformerFactory,
 		cfg.chartFetcher,
 		cfg.recorder(release.AgentName),
+		*cfg.metrics.enqueueRel,
 	)
 
 	cfg.wg.Add(1)

--- a/ops/spin-local-kind.sh
+++ b/ops/spin-local-kind.sh
@@ -40,13 +40,6 @@ kubectl config use-context kind-mgmt
 # setup clusters
 SETUP_MGMT_FLAGS="--webhook-ignore" make clean setup
 
-# fix kind-app clusters:
-for node in $(kind get nodes --name app); do
-  APIMASTER=$(kind get kubeconfig --name app --internal | grep server | grep -Eo 'https.*')
-  PATCH="{\"spec\":{\"apiMaster\":\"${APIMASTER}\"}}"
-  kubectl patch clusters kind-app --type=merge -p "${PATCH}"
-done
-
 INSTALL=${INSTALL:="false"}
 if [[ ${INSTALL} == "true" ]]; then
     echo " =============== Installing shipper-mgmt"
@@ -57,3 +50,10 @@ if [[ ${INSTALL} == "true" ]]; then
         DOCKER_REGISTRY=${REGISTRY} IMAGE_TAG=${IMAGE_TAG} SHIPPER_APP_IMAGE=${SHIPPER_APP_IMAGE} make install-shipper-app
     fi
 fi
+
+# fix kind-app clusters:
+for node in $(kind get nodes --name app); do
+  APIMASTER=$(kind get kubeconfig --name app --internal | grep server | grep -Eo 'https.*')
+  PATCH="{\"spec\":{\"apiMaster\":\"${APIMASTER}\"}}"
+  kubectl patch clusters kind-app --type=merge -p "${PATCH}"
+done

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shippermetrics "github.com/bookingcom/shipper/pkg/metrics/prometheus"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 	"github.com/bookingcom/shipper/pkg/util/conditions"
 	releaseutil "github.com/bookingcom/shipper/pkg/util/release"
@@ -504,6 +505,7 @@ func runController(f *shippertesting.ControllerTestFixture) {
 		f.ShipperInformerFactory,
 		shippertesting.LocalFetchChart,
 		f.Recorder,
+		*shippermetrics.NewEnqueueMetric(),
 	)
 
 	stopCh := make(chan struct{})

--- a/pkg/metrics/prometheus/enqueue.go
+++ b/pkg/metrics/prometheus/enqueue.go
@@ -1,0 +1,47 @@
+package prometheus
+
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+type EnqueueMetric struct {
+	EnqueueRelGauge        *prom.GaugeVec
+	EnqueuePerClusterGauge *prom.GaugeVec
+}
+
+func NewEnqueueMetric() *EnqueueMetric {
+	return &EnqueueMetric{
+		EnqueueRelGauge: prom.NewGaugeVec(
+			prom.GaugeOpts{
+				Namespace: ns,
+				Subsystem: wqSubsys,
+				Name:      "enqueue_release",
+				Help:      "which objects were triggering enqueueing releases",
+			},
+			[]string{"enqueued_release_name", "triggering_object_name", "triggering_object_kind"},
+		),
+		EnqueuePerClusterGauge: prom.NewGaugeVec(
+			prom.GaugeOpts{
+				Namespace: ns,
+				Subsystem: wqSubsys,
+				Name:      "enqueue_release_per_cluster",
+				Help:      "which objects were triggering enqueueing releases per scheduled cluster",
+			},
+			[]string{"enqueued_release_name", "enqueued_release_cluster", "triggering_object_name", "triggering_object_kind"},
+		),
+	}
+}
+
+func (m *EnqueueMetric) ObserveEnqueueRelease(enqueuedReleaseClusters []string, enqueuedReleaseName, triggeringObjectName, triggeringObjectKind string) {
+	m.EnqueueRelGauge.WithLabelValues(enqueuedReleaseName, triggeringObjectName, triggeringObjectKind).Inc()
+	for _, clusterName := range enqueuedReleaseClusters {
+		m.EnqueuePerClusterGauge.WithLabelValues(enqueuedReleaseName, clusterName, triggeringObjectName, triggeringObjectKind).Inc()
+	}
+}
+
+func (m *EnqueueMetric) GetMetrics() []prom.Collector {
+	return []prom.Collector{
+		m.EnqueueRelGauge,
+		m.EnqueuePerClusterGauge,
+	}
+}

--- a/pkg/util/object/kind.go
+++ b/pkg/util/object/kind.go
@@ -1,0 +1,15 @@
+package object
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Kind(object metav1.Object) string {
+	objKind := strings.TrimPrefix(object.GetSelfLink(), "/apis/shipper.booking.com/v1alpha1/namespaces/")
+	objKind = strings.Trim(objKind, object.GetNamespace())
+	objKind = strings.Trim(objKind, object.GetName())
+	objKind = strings.Trim(objKind, "/")
+	return objKind
+}


### PR DESCRIPTION
Counting the objects that are enqueueing releases and the releases we enqueue. This is so we can monitor the behavior of the controllers and see what is triggering enqueueing releases.