### PR TITLE
Shipperctl count command output option

### DIFF
--- a/cmd/shipperctl/cmd/count.go
+++ b/cmd/shipperctl/cmd/count.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/bookingcom/shipper/cmd/shipperctl/configurator"
+)
+
+var (
+	printOption string
+
+	CountCmd = &cobra.Command{
+		Use:   "count",
+		Short: "count Shipper releases that are scheduled *only* on given clusters",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			switch printOption {
+			case "", "json", "yaml":
+				return
+			default:
+				cmd.Printf("error: output format %q not supported, allowed formats are: json, yaml\n", printOption)
+				os.Exit(1)
+			}
+		},
+	}
+
+	countContendersCmd = &cobra.Command{
+		Use:   "contender",
+		Short: "count Shipper *contenders* that are scheduled *only* on given clusters",
+		RunE:  runCountContenderCommand,
+	}
+
+	countReleasesCmd = &cobra.Command{
+		Use:   "release",
+		Short: "count Shipper *releases* that are scheduled *only* on given clusters",
+		RunE:  runCountReleasesCommand,
+	}
+)
+
+type OutputRelease struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func init() {
+	// Flags common to all commands under `shipperctl count`
+	CountCmd.PersistentFlags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "The path to the Kubernetes configuration file")
+	if err := CountCmd.MarkPersistentFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
+		CountCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
+	}
+
+	CountCmd.PersistentFlags().StringVar(&managementClusterContext, "management-cluster-context", "", "The name of the context to use to communicate with the management cluster. defaults to the current one")
+	CountCmd.PersistentFlags().StringSliceVar(&clusters, clustersFlagName, clusters, "List of comma separated clusters to count releases that are scheduled on. (Required)")
+	if err := CountCmd.MarkPersistentFlagRequired(clustersFlagName); err != nil {
+		CountCmd.Printf("warning: could not mark %q as required: %s\n", clustersFlagName, err)
+	}
+	CountCmd.PersistentFlags().StringVarP(&printOption, "output", "o", "", "Output format. One of: json|yaml. (Optional)")
+
+	CountCmd.AddCommand(countContendersCmd)
+	CountCmd.AddCommand(countReleasesCmd)
+}
+
+func runCountContenderCommand(cmd *cobra.Command, args []string) error {
+	counter := 0
+	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+	var countedReleases []OutputRelease
+	for _, ns := range namespaceList.Items {
+		applicationList, err := configurator.ShipperClient.ShipperV1alpha1().Applications(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+		for _, app := range applicationList.Items {
+			contender, err := getContender(&app, configurator)
+			if err != nil {
+				errList = append(errList, err.Error())
+				continue
+			}
+			trueClusters := getFilteredSelectedClusters(contender)
+			if len(trueClusters) == 0 {
+				counter++
+				countedReleases = append(
+					countedReleases,
+					OutputRelease{
+						Namespace: contender.Namespace,
+						Name:      contender.Name,
+					})
+			}
+		}
+	}
+
+	if printOption == "" {
+		cmd.Println("Number of *contenders* that are scheduled only on decommissioned clusters: ", counter)
+	} else {
+		printCountedRelease(countedReleases)
+	}
+	if len(errList) > 0 {
+		return fmt.Errorf(strings.Join(errList, ","))
+	}
+	return nil
+}
+
+func runCountReleasesCommand(cmd *cobra.Command, args []string) error {
+	counter := 0
+
+	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+	var countedReleases []OutputRelease
+	for _, ns := range namespaceList.Items {
+		releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+		for _, rel := range releaseList.Items {
+			trueClusters := getFilteredSelectedClusters(&rel)
+			if len(trueClusters) == 0 {
+				counter++
+				countedReleases = append(
+					countedReleases,
+					OutputRelease{
+						Namespace: rel.Namespace,
+						Name:      rel.Name,
+					})
+			}
+		}
+	}
+
+	if printOption == "" {
+		cmd.Println("Number of *releases* that are scheduled only on decommissioned clusters: ", counter)
+	} else {
+		printCountedRelease(countedReleases)
+	}
+	if len(errList) > 0 {
+		return fmt.Errorf(strings.Join(errList, ","))
+	}
+	return nil
+}
+
+func printCountedRelease(outputReleases []OutputRelease) {
+	var err error
+	var data []byte
+
+	switch printOption {
+	case "yaml":
+		data, err = yaml.Marshal(outputReleases)
+	case "json":
+		data, err = json.MarshalIndent(outputReleases, "", "    ")
+	case "":
+		return
+	}
+	if err != nil {
+		os.Stderr.Write(bytes.NewBufferString(err.Error()).Bytes())
+		return
+	}
+
+	_, _ = os.Stdout.Write(data)
+}

--- a/cmd/shipperctl/cmd/decommission.go
+++ b/cmd/shipperctl/cmd/decommission.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,13 +17,12 @@ import (
 )
 
 const (
-	decommissionedClustersFlagName = "decommissionedClusters"
+	clustersFlagName = "clusters"
 )
 
 var (
-	decommissionedClusters []string
-	dryrun                 bool
-	printOption            string
+	clusters []string
+	dryrun   bool
 
 	CleanCmd = &cobra.Command{
 		Use:   "clean",
@@ -41,61 +36,23 @@ var (
 			"removing decommissioned clusters from annotations of releases that are scheduled partially on decommissioned clusters.",
 		RunE: runCleanCommand,
 	}
-
-	CountCmd = &cobra.Command{
-		Use:   "count",
-		Short: "count Shipper releases that are scheduled *only* on decommissioned clusters",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			switch printOption {
-			case "", "json", "yaml":
-				return
-			default:
-				cmd.Printf("error: output format %q not supported, allowed formats are: json, yaml\n", printOption)
-				os.Exit(1)
-			}
-		},
-	}
-
-	countContendersCmd = &cobra.Command{
-		Use:   "contender",
-		Short: "count Shipper *contenders* that are scheduled *only* on decommissioned clusters",
-		RunE:  runCountContenderCommand,
-	}
-
-	countReleasesCmd = &cobra.Command{
-		Use:   "release",
-		Short: "count Shipper *releases* that are scheduled *only* on decommissioned clusters",
-		RunE:  runCountReleasesCommand,
-	}
 )
 
-type OutputRelease struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-}
-
 func init() {
-	// Flags common to all commands under `shipperctl clean/count`
-	for _, command := range []*cobra.Command{CountCmd, CleanCmd} {
-		command.PersistentFlags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "the path to the Kubernetes configuration file")
-		if err := command.MarkPersistentFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
-			command.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
-		}
-
-		command.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "If true, only prints the objects that will be modifies/deleted")
-		command.PersistentFlags().StringVar(&managementClusterContext, "management-cluster-context", "", "The name of the context to use to communicate with the management cluster. defaults to the current one")
-		command.PersistentFlags().StringSliceVar(&decommissionedClusters, decommissionedClustersFlagName, decommissionedClusters, "List of decommissioned clusters. (Required)")
-		if err := command.MarkPersistentFlagRequired(decommissionedClustersFlagName); err != nil {
-			command.Printf("warning: could not mark %q as required: %s\n", decommissionedClustersFlagName, err)
-		}
-
+	// Flags common to all commands under `shipperctl clean`
+	CleanCmd.PersistentFlags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "The path to the Kubernetes configuration file")
+	if err := CleanCmd.MarkPersistentFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
+		CleanCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
 	}
-	// Flags common to all commands under `shipperctl count`
-	CountCmd.PersistentFlags().StringVarP(&printOption, "output", "o", "", "Output format. One of: json|yaml. Optional")
+
+	CleanCmd.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "If true, only prints the objects that will be modified/deleted")
+	CleanCmd.PersistentFlags().StringVar(&managementClusterContext, "management-cluster-context", "", "The name of the context to use to communicate with the management cluster. defaults to the current one")
+	CleanCmd.PersistentFlags().StringSliceVar(&clusters, clustersFlagName, clusters, "List of decommissioned clusters. (Required)")
+	if err := CleanCmd.MarkPersistentFlagRequired(clustersFlagName); err != nil {
+		CleanCmd.Printf("warning: could not mark %q as required: %s\n", clustersFlagName, err)
+	}
 
 	CleanCmd.AddCommand(cleanDeadClustersCmd)
-	CountCmd.AddCommand(countContendersCmd)
-	CountCmd.AddCommand(countReleasesCmd)
 }
 
 func runCleanCommand(cmd *cobra.Command, args []string) error {
@@ -162,125 +119,11 @@ func runCleanCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runCountContenderCommand(cmd *cobra.Command, args []string) error {
-	counter := 0
-	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
-	if err != nil {
-		return err
-	}
-
-	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	var errList []string
-	var countedReleases []OutputRelease
-	for _, ns := range namespaceList.Items {
-		applicationList, err := configurator.ShipperClient.ShipperV1alpha1().Applications(ns.Name).List(metav1.ListOptions{})
-		if err != nil {
-			errList = append(errList, err.Error())
-			continue
-		}
-		for _, app := range applicationList.Items {
-			contender, err := getContender(&app, configurator)
-			if err != nil {
-				errList = append(errList, err.Error())
-				continue
-			}
-			trueClusters := getFilteredSelectedClusters(contender)
-			if len(trueClusters) == 0 {
-				counter++
-				countedReleases = append(
-					countedReleases,
-					OutputRelease{
-						Namespace: contender.Namespace,
-						Name:      contender.Name,
-					})
-			}
-		}
-	}
-
-	if printOption == "" {
-		cmd.Println("Number of *contenders* that are scheduled only on decommissioned clusters: ", counter)
-	} else {
-		printCountedRelease(countedReleases)
-	}
-	if len(errList) > 0 {
-		return fmt.Errorf(strings.Join(errList, ","))
-	}
-	return nil
-}
-
-func runCountReleasesCommand(cmd *cobra.Command, args []string) error {
-	counter := 0
-
-	configurator, err := configurator.NewClusterConfiguratorFromKubeConfig(kubeConfigFile, managementClusterContext)
-	if err != nil {
-		return err
-	}
-
-	namespaceList, err := configurator.KubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	var errList []string
-	var countedReleases []OutputRelease
-	for _, ns := range namespaceList.Items {
-		releaseList, err := configurator.ShipperClient.ShipperV1alpha1().Releases(ns.Name).List(metav1.ListOptions{})
-		if err != nil {
-			errList = append(errList, err.Error())
-			continue
-		}
-		for _, rel := range releaseList.Items {
-			trueClusters := getFilteredSelectedClusters(&rel)
-			if len(trueClusters) == 0 {
-				counter++
-				countedReleases = append(
-					countedReleases,
-					OutputRelease{
-						Namespace: rel.Namespace,
-						Name:      rel.Name,
-					})
-			}
-		}
-	}
-
-	if printOption == "" {
-		cmd.Println("Number of *releases* that are scheduled only on decommissioned clusters: ", counter)
-	} else {
-		printCountedRelease(countedReleases)
-	}
-	if len(errList) > 0 {
-		return fmt.Errorf(strings.Join(errList, ","))
-	}
-	return nil
-}
-
-func printCountedRelease(outputReleases []OutputRelease) {
-	var err error
-	var data []byte
-
-	switch printOption {
-	case "yaml":
-		data, err = yaml.Marshal(outputReleases)
-	case "json":
-		data, err = json.MarshalIndent(outputReleases, "", "    ")
-	case "":
-		return
-	}
-	if err != nil {
-		os.Stderr.Write(bytes.NewBufferString(err.Error()).Bytes())
-		return
-	}
-
-	_, _ = os.Stdout.Write(data)
-}
-
 func getFilteredSelectedClusters(rel *shipper.Release) []string {
 	clusters := releaseutil.GetSelectedClusters(rel)
 	var trueClusters []string
 	for _, cluster := range clusters {
-		if !filters.SliceContainsString(decommissionedClusters, cluster) {
+		if !filters.SliceContainsString(clusters, cluster) {
 			trueClusters = append(trueClusters, cluster)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/cespare/xxhash v1.1.0
 	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
+	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
 	github.com/gobwas/glob v0.2.2 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect


### PR DESCRIPTION
This pr adds to the new count command an output option. This allows the users of this command to also get a list of releases for future actions.
For example `shipperctl count contender --decommissionedClusters="decommissioned-a,decommissioned-b"  -o json` 
will output a json of  the form
`[{"namespace": "yfouquet","name": "reserve-backend-test-359dc193-0"},{"namespace": "yfouquet", "name": "reserve-backend-test-359dc193-0" },...]` 
which allows the user to handle these cases separately.