### PR TITLE
Update capacity target in case of "In Progress" status 

### DIFF
--- a/pkg/controller/capacity/capacity_controller.go
+++ b/pkg/controller/capacity/capacity_controller.go
@@ -248,7 +248,7 @@ func (c *Controller) processCapacityTargetOnCluster(
 				InProgress,
 				"",
 			)
-			return nil
+			return shippererrors.NewCapacityInProgressError(ct.Name)
 		}
 	}
 
@@ -263,7 +263,7 @@ func (c *Controller) processCapacityTargetOnCluster(
 			"",
 		)
 
-		return nil
+		return shippererrors.NewCapacityInProgressError(ct.Name)
 	}
 
 	// If the number of available replicas matches what we want, the
@@ -329,6 +329,10 @@ func (c *Controller) processCapacityTargetOnCluster(
 		reason,
 		msg,
 	)
+
+	if reason == InProgress {
+		return shippererrors.NewCapacityInProgressError(ct.Name)
+	}
 
 	return nil
 }

--- a/pkg/errors/capacity.go
+++ b/pkg/errors/capacity.go
@@ -1,0 +1,20 @@
+package errors
+
+import (
+	"fmt"
+)
+
+type CapacityInProgressError string
+
+func (e CapacityInProgressError) Error() string {
+	return string(e)
+}
+
+func (e CapacityInProgressError) ShouldRetry() bool {
+	return true
+}
+
+func NewCapacityInProgressError(ctName string) CapacityInProgressError {
+	return CapacityInProgressError(fmt.Sprintf("capacity target %s in progress",
+		ctName))
+}


### PR DESCRIPTION
#328 

> At the beginning of a rollout, the installation controller will install the deployment with 0 replica set. 
> Then the capacity controller will patch the deployment,
> and update the capacity targets status with a condition “Ready false, In Progress”.
> When a new pod finishes starting and starts spinning the containers,
> the deployment’s status gets a condition "Available false" (since the pod is not available yet).
> The capacity target condition is still "in progress" here since there is progress, the pod is starting,
> there are no sad pods, and no devastating statuses in the deployment.
>
> When the pod starts failing, for example with a CrashLoop,
>  the deployment object is not getting a new condition,
> and the capacity target is still reporting "in progress"
> (since the capacity controller is listening to deployments objects and there was no update to the deployment).
>
> Solution: when Shipper is marking the capacity target “in progress”,
> shipper must re-check and take the CT out of this temporary state.
> We do that by raising a retriable error when the CT is "in progress"
> to re-enqueue the CT until the temporary status is updated.