### PR TITLE
shipperctl backup commands

### DIFF
--- a/cmd/shipperctl/cmd/backup/backup.go
+++ b/cmd/shipperctl/cmd/backup/backup.go
@@ -32,9 +32,16 @@ var (
 	}
 )
 
-type shipperBackupObject struct {
-	Application shipper.Application `json:"application"`
-	Releases    []shipper.Release   `json:"releases"`
+type shipperBackupApplication struct {
+	Application    shipper.Application    `json:"application"`
+	BackupReleases []shipperBackupRelease `json:"backup_releases"`
+}
+
+type shipperBackupRelease struct {
+	Release            shipper.Release            `json:"release"`
+	InstallationTarget shipper.InstallationTarget `json:"installation_target"`
+	TrafficTarget      shipper.TrafficTarget      `json:"traffic_target"`
+	CapacityTarget     shipper.CapacityTarget     `json:"capacity_target"`
 }
 
 func init() {
@@ -61,22 +68,22 @@ func init() {
 	}
 }
 
-func marshalReleasesPerApplications(releasesPerApplications []shipperBackupObject) ([]byte, error) {
+func marshalReleasesPerApplications(releasesPerApplications []shipperBackupApplication) ([]byte, error) {
 	if outputFormat == "json" {
 		return json.MarshalIndent(releasesPerApplications, "", "    ")
 	}
 	return yaml.Marshal(releasesPerApplications)
 }
 
-func printReleasesPerApplications(releasesPerApplications []shipperBackupObject) {
+func printReleasesPerApplications(releasesPerApplications []shipperBackupApplication) {
 	tbl := table.New(
 		"NAMESPACE",
 		"RELEASE NAME",
 		"OWNING APPLICATION",
 	)
 	for _, obj := range releasesPerApplications {
-		for _, rel := range obj.Releases {
-
+		for _, backupRelease := range obj.BackupReleases {
+			rel := backupRelease.Release
 			tbl.AddRow(
 				rel.Namespace,
 				rel.Name,

--- a/cmd/shipperctl/cmd/backup/backup.go
+++ b/cmd/shipperctl/cmd/backup/backup.go
@@ -1,0 +1,89 @@
+package backup
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+)
+
+var (
+	outputFormat             = "yaml"
+	kubeConfigFile           string
+	managementClusterContext string
+	verboseFlag              bool
+
+	BackupCmd = &cobra.Command{
+		Use:   "backup",
+		Short: "Backup and restore Shipper applications and releases",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			switch outputFormat {
+			case "json", "yaml":
+				return
+			default:
+				cmd.Printf("error: output format %q not supported, allowed formats are: json, yaml\n", outputFormat)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+type shipperBackupObject struct {
+	Application shipper.Application `json:"application"`
+	Releases    []shipper.Release   `json:"releases"`
+}
+
+func init() {
+	kubeConfigFlagName := "kubeconfig"
+	fileFlagName := "file"
+
+	BackupCmd.PersistentFlags().StringVar(&kubeConfigFile, kubeConfigFlagName, "~/.kube/config", "The path to the Kubernetes configuration file")
+	if err := BackupCmd.MarkPersistentFlagFilename(kubeConfigFlagName, "yaml"); err != nil {
+		BackupCmd.Printf("warning: could not mark %q for filename autocompletion: %s\n", kubeConfigFlagName, err)
+	}
+
+	BackupCmd.PersistentFlags().StringVar(&managementClusterContext, "management-cluster-context", "", "The name of the context to use to communicate with the management cluster. defaults to the current one")
+	BackupCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Prints the list of backup items")
+	BackupCmd.PersistentFlags().StringVar(&outputFormat, "format", "yaml", "Output format. One of: json|yaml")
+
+	BackupCmd.PersistentFlags().StringVarP(&backupFile, fileFlagName, "f", "backup.yaml", "The path to a backup file")
+	err := BackupCmd.MarkPersistentFlagFilename(fileFlagName, "yaml")
+	if err != nil {
+		BackupCmd.Printf("warning: could not mark %q for filename yaml autocompletion: %s\n", fileFlagName, err)
+	}
+	err = BackupCmd.MarkPersistentFlagFilename(fileFlagName, "json")
+	if err != nil {
+		BackupCmd.Printf("warning: could not mark %q for filename json autocompletion: %s\n", fileFlagName, err)
+	}
+}
+
+func marshalReleasesPerApplications(releasesPerApplications []shipperBackupObject) ([]byte, error) {
+	if outputFormat == "json" {
+		return json.MarshalIndent(releasesPerApplications, "", "    ")
+	}
+	return yaml.Marshal(releasesPerApplications)
+}
+
+func printReleasesPerApplications(releasesPerApplications []shipperBackupObject) {
+	tbl := table.New(
+		"NAMESPACE",
+		"RELEASE NAME",
+		"OWNING APPLICATION",
+	)
+	for _, obj := range releasesPerApplications {
+		for _, rel := range obj.Releases {
+
+			tbl.AddRow(
+				rel.Namespace,
+				rel.Name,
+				obj.Application.Name,
+			)
+		}
+	}
+
+	tbl.Print()
+}

--- a/cmd/shipperctl/cmd/backup/backup.go
+++ b/cmd/shipperctl/cmd/backup/backup.go
@@ -68,20 +68,20 @@ func init() {
 	}
 }
 
-func marshalReleasesPerApplications(releasesPerApplications []shipperBackupApplication) ([]byte, error) {
+func marshalShipperBackupApplication(shipperBackupApplication []shipperBackupApplication) ([]byte, error) {
 	if outputFormat == "json" {
-		return json.MarshalIndent(releasesPerApplications, "", "    ")
+		return json.MarshalIndent(shipperBackupApplication, "", "    ")
 	}
-	return yaml.Marshal(releasesPerApplications)
+	return yaml.Marshal(shipperBackupApplication)
 }
 
-func printReleasesPerApplications(releasesPerApplications []shipperBackupApplication) {
+func printShipperBackupApplication(shipperBackupApplication []shipperBackupApplication) {
 	tbl := table.New(
 		"NAMESPACE",
 		"RELEASE NAME",
 		"OWNING APPLICATION",
 	)
-	for _, obj := range releasesPerApplications {
+	for _, obj := range shipperBackupApplication {
 		for _, backupRelease := range obj.BackupReleases {
 			rel := backupRelease.Release
 			tbl.AddRow(

--- a/cmd/shipperctl/cmd/backup/prepare.go
+++ b/cmd/shipperctl/cmd/backup/prepare.go
@@ -1,0 +1,101 @@
+package backup
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/bookingcom/shipper/cmd/shipperctl/configurator"
+	"github.com/bookingcom/shipper/cmd/shipperctl/release"
+	"github.com/bookingcom/shipper/cmd/shipperctl/ui"
+)
+
+var (
+	prepareBackupCmd = &cobra.Command{
+		Use:   "prepare",
+		Short: "Get yaml of application and release objects prepared for backup",
+		Long: "Get yaml of application and release objects prepared for backup" +
+			"where every application will be bundled with it's releases",
+		RunE: runPrepareCommand,
+	}
+)
+
+func init() {
+	BackupCmd.AddCommand(prepareBackupCmd)
+}
+
+func runPrepareCommand(cmd *cobra.Command, args []string) error {
+	kubeClient, err := configurator.NewKubeClientFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	shipperClient, err := configurator.NewShipperClientFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	namespaceList, err := kubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	var errList []string
+
+	releasesPerApplications := []shipperBackupObject{}
+	for _, ns := range namespaceList.Items {
+		applicationList, err := shipperClient.ShipperV1alpha1().Applications(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			errList = append(errList, err.Error())
+			continue
+		}
+
+		for _, app := range applicationList.Items {
+			releaseList, err := release.ReleasesForApplication(app.Name, app.Namespace, shipperClient)
+			if err != nil {
+				errList = append(errList, err.Error())
+				continue
+			}
+			releasesPerApplications = append(
+				releasesPerApplications,
+				shipperBackupObject{
+					Application: app,
+					Releases:    releaseList.Items,
+				},
+			)
+		}
+	}
+	if len(errList) > 0 {
+		confirm, err := ui.AskForConfirmation(
+			cmd.InOrStdin(),
+			fmt.Sprintf(
+				"Found errors while retreiving objects: %s. Continue anyway?",
+				strings.Join(errList, ", "),
+			),
+		)
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return fmt.Errorf(strings.Join(errList, ", "))
+		}
+	}
+
+	if verboseFlag {
+		printReleasesPerApplications(releasesPerApplications)
+	}
+	data, err := marshalReleasesPerApplications(releasesPerApplications)
+	if err != nil {
+		return err
+	} else {
+		err := ioutil.WriteFile(backupFile, data, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Backup objects stored in %q\n", backupFile)
+	return nil
+}

--- a/cmd/shipperctl/cmd/backup/prepare_test.go
+++ b/cmd/shipperctl/cmd/backup/prepare_test.go
@@ -1,0 +1,276 @@
+package backup
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+)
+
+func TestBuildShipperBackupApplication(t *testing.T) {
+	application := shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testAppName,
+			Namespace: testNamespaceName,
+			UID:       appUid,
+		},
+		Spec: shipper.ApplicationSpec{
+			RevisionHistoryLimit: nil,
+			Template: shipper.ReleaseEnvironment{
+				Chart: shipper.Chart{
+					Name:    "",
+					Version: "",
+					RepoURL: "",
+				},
+				Values: nil,
+				ClusterRequirements: shipper.ClusterRequirements{
+					Regions:      nil,
+					Capabilities: nil,
+				},
+			},
+		},
+		Status: shipper.ApplicationStatus{},
+	}
+	release := shipper.Release{
+		ObjectMeta: metav1.ObjectMeta{
+
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			UID:       relUid,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "",
+					Kind:       "",
+					Name:       "",
+					UID:        appUid,
+				},
+			},
+			Labels: map[string]string{
+				shipper.AppLabel: testAppName,
+			},
+		},
+		Spec: shipper.ReleaseSpec{
+			TargetStep: 0,
+			Environment: shipper.ReleaseEnvironment{
+				Chart: shipper.Chart{
+					Name:    "",
+					Version: "",
+					RepoURL: "",
+				},
+				Values: nil,
+				ClusterRequirements: shipper.ClusterRequirements{
+					Regions:      nil,
+					Capabilities: nil,
+				},
+			},
+		},
+		Status: shipper.ReleaseStatus{},
+	}
+	installationTarget := shipper.InstallationTarget{
+		ObjectMeta: metav1.ObjectMeta{
+
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "",
+					Kind:       "",
+					Name:       "",
+					UID:        relUid,
+				},
+			},
+			Labels: map[string]string{
+				shipper.ReleaseLabel: testRelName,
+			},
+		},
+		Spec: shipper.InstallationTargetSpec{
+			Clusters:    nil,
+			CanOverride: false,
+			Chart:       nil,
+		},
+		Status: shipper.InstallationTargetStatus{},
+	}
+	trafficTarget := shipper.TrafficTarget{
+		ObjectMeta: metav1.ObjectMeta{
+
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "",
+					Kind:       "",
+					Name:       "",
+					UID:        relUid,
+				},
+			},
+			Labels: map[string]string{
+				shipper.ReleaseLabel: testRelName,
+			},
+		},
+		Spec: shipper.TrafficTargetSpec{
+			Clusters: nil,
+		},
+		Status: shipper.TrafficTargetStatus{},
+	}
+	capacityTarget := shipper.CapacityTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{
+				Time: time.Time{},
+			},
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "",
+					Kind:       "",
+					Name:       "",
+					UID:        relUid,
+				},
+			},
+			Labels: map[string]string{
+				shipper.ReleaseLabel: testRelName,
+			},
+		},
+		Spec: shipper.CapacityTargetSpec{
+			Clusters: nil,
+		},
+		Status: shipper.CapacityTargetStatus{},
+	}
+
+	tests := []struct {
+		Name           string
+		ExpectedBackup []shipperBackupApplication
+		ExpectedError  error
+		PreTest        func() (*shipperfake.Clientset, *kubefake.Clientset, error)
+	}{
+		{
+			Name: "One application with one release tree",
+			ExpectedBackup: []shipperBackupApplication{
+				{
+					Application: application,
+					BackupReleases: []shipperBackupRelease{
+						{
+							Release:            release,
+							InstallationTarget: installationTarget,
+							TrafficTarget:      trafficTarget,
+							CapacityTarget:     capacityTarget,
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+			PreTest: func() (*shipperfake.Clientset, *kubefake.Clientset, error) {
+				shipperfakeClient := shipperfake.NewSimpleClientset()
+				kubefakeClient := kubefake.NewSimpleClientset()
+				namespace := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespaceName,
+					},
+				}
+				if _, err := kubefakeClient.CoreV1().Namespaces().Create(&namespace); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().Applications(testNamespaceName).Create(&application); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().Releases(testNamespaceName).Create(&release); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().InstallationTargets(testNamespaceName).Create(&installationTarget); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().TrafficTargets(testNamespaceName).Create(&trafficTarget); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().CapacityTargets(testNamespaceName).Create(&capacityTarget); err != nil {
+					return nil, nil, err
+				}
+
+				return shipperfakeClient, kubefakeClient, nil
+			},
+		},
+		{
+			Name:           "One application with release and missing target objects",
+			ExpectedBackup: nil,
+			ExpectedError: fmt.Errorf(
+				"Failed to retrieve some objects:\n - expected 1 shipper.booking.com/v1alpha1, Kind=%s for selector \"%s=%s\", got %d instead\n",
+				"InstallationTarget",
+				shipper.ReleaseLabel,
+				testRelName,
+				0,
+			),
+			PreTest: func() (*shipperfake.Clientset, *kubefake.Clientset, error) {
+				shipperfakeClient := shipperfake.NewSimpleClientset()
+				kubefakeClient := kubefake.NewSimpleClientset()
+				namespace := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespaceName,
+					},
+				}
+				if _, err := kubefakeClient.CoreV1().Namespaces().Create(&namespace); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().Applications(testNamespaceName).Create(&application); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().Releases(testNamespaceName).Create(&release); err != nil {
+					return nil, nil, err
+				}
+
+				return shipperfakeClient, kubefakeClient, nil
+			},
+		},
+		{
+			Name: "One application with no release or target objects",
+			ExpectedBackup: []shipperBackupApplication{
+				{
+					Application:    application,
+					BackupReleases: []shipperBackupRelease{},
+				},
+			},
+			ExpectedError: nil,
+			PreTest: func() (*shipperfake.Clientset, *kubefake.Clientset, error) {
+				shipperfakeClient := shipperfake.NewSimpleClientset()
+				kubefakeClient := kubefake.NewSimpleClientset()
+				namespace := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespaceName,
+					},
+				}
+				if _, err := kubefakeClient.CoreV1().Namespaces().Create(&namespace); err != nil {
+					return nil, nil, err
+				}
+				if _, err := shipperfakeClient.ShipperV1alpha1().Applications(testNamespaceName).Create(&application); err != nil {
+					return nil, nil, err
+				}
+
+				return shipperfakeClient, kubefakeClient, nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			shipperFakeClient, kubefakeClient, err := test.PreTest()
+			if err != nil {
+				t.Fatalf("unexpected error \n%v", err)
+			}
+			actualBackup, actualErr := buildShipperBackupApplication(kubefakeClient, shipperFakeClient)
+			if !reflect.DeepEqual(actualErr, test.ExpectedError) {
+				t.Fatalf("expected error \n%v\ngot error \n%v", test.ExpectedError, actualErr)
+			}
+			eq, diff := shippertesting.DeepEqualDiff(actualBackup, test.ExpectedBackup)
+			if !eq {
+				t.Fatalf("backup differ from expected:\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/shipperctl/cmd/backup/restore.go
+++ b/cmd/shipperctl/cmd/backup/restore.go
@@ -1,0 +1,193 @@
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/yaml"
+
+	"github.com/bookingcom/shipper/cmd/shipperctl/configurator"
+	"github.com/bookingcom/shipper/cmd/shipperctl/ui"
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperclientset "github.com/bookingcom/shipper/pkg/client/clientset/versioned"
+)
+
+var (
+	backupFile string
+
+	restoreBackupCmd = &cobra.Command{
+		Use:   "restore",
+		Short: "Restore backup that was prepared using `shipperctl prepare` command",
+		Long: "Restore backup that was prepared using `shipperctl prepare` command" +
+			"this will update the owner reference of releases objects",
+		RunE: runRestoreCommand,
+	}
+)
+
+func init() {
+	BackupCmd.AddCommand(restoreBackupCmd)
+}
+
+func runRestoreCommand(cmd *cobra.Command, args []string) error {
+	kubeClient, err := configurator.NewKubeClientFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	shipperClient, err := configurator.NewShipperClientFromKubeConfig(kubeConfigFile, managementClusterContext)
+	if err != nil {
+		return err
+	}
+
+	releasesPerApplications, err := unmarshalReleasesPerApplicationFromFile()
+	if err != nil {
+		return err
+	}
+
+	confirm, err := ui.AskForConfirmation(cmd.InOrStdin(), "Would you like to see an overview of your backup?")
+	if err != nil {
+		return err
+	}
+	if confirm {
+		printReleasesPerApplications(releasesPerApplications)
+		confirm, err = ui.AskForConfirmation(cmd.InOrStdin(), "Would you like to review backup?")
+		if err != nil {
+			return err
+		}
+		if confirm {
+			data, err := marshalReleasesPerApplications(releasesPerApplications)
+			if err != nil {
+				return err
+			}
+			if _, err := cmd.OutOrStdout().Write(data); err != nil {
+				return err
+			}
+		}
+	}
+
+	confirm, err = ui.AskForConfirmation(cmd.InOrStdin(), "Would you like to restore backup?")
+	if err != nil {
+		return err
+	}
+	if !confirm {
+		return nil
+	}
+
+	if err := restore(releasesPerApplications, kubeClient, shipperClient); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func restore(releasesPerApplications []shipperBackupObject, kubeClient kubernetes.Interface, shipperClient shipperclientset.Interface) error {
+	for _, obj := range releasesPerApplications {
+		// apply application
+		if err := applyApplication(kubeClient, shipperClient, obj.Application); err != nil {
+			return err
+		}
+		fmt.Printf("application %q created\n", fmt.Sprintf("%s/%s", obj.Application.Namespace, obj.Application.Name))
+
+		// get the new UID
+		uid, err := uidOfApplication(shipperClient, obj.Application.Name, obj.Application.Namespace)
+		if err != nil {
+			return err
+		}
+
+		// update owner ref for all releases and apply them
+		for _, release := range obj.Releases {
+			rel, err := updateOwnerRefUid(release, *uid)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("release %q owner reference updates with uid %q\n", fmt.Sprintf("%s/%s", rel.Namespace, rel.Name), *uid)
+
+			rel.ResourceVersion = ""
+			if _, err = shipperClient.ShipperV1alpha1().Releases(rel.Namespace).Create(rel); err != nil {
+				return err
+			}
+			fmt.Printf("release %q created\n", fmt.Sprintf("%s/%s", rel.Namespace, rel.Name))
+		}
+
+	}
+	return nil
+}
+
+func applyApplication(kubeClient kubernetes.Interface, shipperClient shipperclientset.Interface, app shipper.Application) error {
+	// make sure namespace exists
+	ns, err := kubeClient.CoreV1().Namespaces().Get(app.Namespace, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// create ns:
+			newNs := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: app.Namespace,
+				},
+			}
+			if ns, err = kubeClient.CoreV1().Namespaces().Create(&newNs); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	// apply application
+	app.ResourceVersion = ""
+	if _, err = shipperClient.ShipperV1alpha1().Applications(ns.Name).Create(&app); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func uidOfApplication(shipperClient shipperclientset.Interface, appName, appNamespace string) (*types.UID, error) {
+	application, err := shipperClient.ShipperV1alpha1().Applications(appNamespace).Get(appName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	uid := application.GetUID()
+	return &uid, nil
+}
+
+func updateOwnerRefUid(rel shipper.Release, uid types.UID) (*shipper.Release, error) {
+	ownerReferences := rel.GetOwnerReferences()
+	if n := len(rel.OwnerReferences); n != 1 {
+		key, _ := cache.MetaNamespaceKeyFunc(rel)
+		return nil, fmt.Errorf("expected exactly one owner for Release %q but got %d", key, n)
+	}
+	ownerReferences[0].UID = uid
+	rel.SetOwnerReferences(ownerReferences)
+	return &rel, nil
+}
+
+func unmarshalReleasesPerApplicationFromFile() ([]shipperBackupObject, error) {
+	backupBytes, err := ioutil.ReadFile(backupFile)
+	if err != nil {
+		return nil, err
+	}
+
+	releasesPerApplications := &[]shipperBackupObject{}
+
+	switch outputFormat {
+	case "yaml":
+		err = yaml.Unmarshal(backupBytes, releasesPerApplications)
+		if err != nil {
+			return nil, err
+		}
+	case "json":
+		err = json.Unmarshal(backupBytes, releasesPerApplications)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return *releasesPerApplications, nil
+}

--- a/cmd/shipperctl/cmd/backup/restore.go
+++ b/cmd/shipperctl/cmd/backup/restore.go
@@ -117,7 +117,7 @@ func restore(shipperBackupApplications []shipperBackupApplication, kubeClient ku
 			rel := &backupRelease.Release
 			err := updateOwnerRefUid(&rel.ObjectMeta, uid)
 			if err != nil {
-				return err
+				return fmt.Errorf("faild to update release owner reference: %v", err)
 			}
 			fmt.Printf("release %q owner reference updates with uid %q\n", fmt.Sprintf("%s/%s", rel.Namespace, rel.Name), uid)
 
@@ -147,7 +147,7 @@ func restore(shipperBackupApplications []shipperBackupApplication, kubeClient ku
 func restoreTargetObjects(backupRelease shipperBackupRelease, relUid types.UID, shipperClient shipperclientset.Interface) error {
 	// InstallationTarget
 	if err := updateOwnerRefUid(&backupRelease.InstallationTarget.ObjectMeta, relUid); err != nil {
-		return err
+		return fmt.Errorf("faild to update installation target owner reference: %v", err)
 	}
 	fmt.Printf(
 		"installation target %q owner reference updates with uid %q\n",
@@ -162,7 +162,7 @@ func restoreTargetObjects(backupRelease shipperBackupRelease, relUid types.UID, 
 
 	// TrafficTarget
 	if err := updateOwnerRefUid(&backupRelease.TrafficTarget.ObjectMeta, relUid); err != nil {
-		return err
+		return fmt.Errorf("faild to update traffic target owner reference: %v", err)
 	}
 	fmt.Printf(
 		"traffic target %q owner reference updates with uid %q\n",
@@ -177,7 +177,7 @@ func restoreTargetObjects(backupRelease shipperBackupRelease, relUid types.UID, 
 
 	// CapacityTarget
 	if err := updateOwnerRefUid(&backupRelease.CapacityTarget.ObjectMeta, relUid); err != nil {
-		return err
+		return fmt.Errorf("faild to update capacity target owner reference: %v", err)
 	}
 	fmt.Printf(
 		"capacity target %q owner reference updates with uid %q\n",
@@ -223,7 +223,7 @@ func applyApplication(kubeClient kubernetes.Interface, shipperClient shipperclie
 func uidOfApplication(shipperClient shipperclientset.Interface, appName, appNamespace string) (types.UID, error) {
 	application, err := shipperClient.ShipperV1alpha1().Applications(appNamespace).Get(appName, metav1.GetOptions{})
 	if err != nil {
-		return types.UID(""), err
+		return types.UID(""), fmt.Errorf("failed to get application: %v", err)
 	}
 	uid := application.GetUID()
 	return uid, nil
@@ -232,7 +232,7 @@ func uidOfApplication(shipperClient shipperclientset.Interface, appName, appName
 func uidOfRelease(shipperClient shipperclientset.Interface, relName, relNamespace string) (types.UID, error) {
 	release, err := shipperClient.ShipperV1alpha1().Releases(relNamespace).Get(relName, metav1.GetOptions{})
 	if err != nil {
-		return types.UID(""), err
+		return types.UID(""), fmt.Errorf("failed to get release: %v", err)
 	}
 	uid := release.GetUID()
 	return uid, nil

--- a/cmd/shipperctl/cmd/backup/restore_test.go
+++ b/cmd/shipperctl/cmd/backup/restore_test.go
@@ -1,0 +1,437 @@
+package backup
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+)
+
+const (
+	testNamespaceName           = "unit-test-namespace"
+	testAppName                 = "unit-test-app"
+	testRelName                 = "unit-test-release"
+	appUid            types.UID = "app-UID"
+	relUid            types.UID = "rel-UID"
+)
+
+func TestRestore(t *testing.T) {
+	application := shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testAppName,
+			Namespace: testNamespaceName,
+			UID:       appUid,
+		},
+	}
+	release := shipper.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			UID:       relUid,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: "just-a-UID",
+				},
+			},
+		},
+	}
+	installationTarget := shipper.InstallationTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: "just-another-UID",
+				},
+			},
+		},
+	}
+	trafficTarget := shipper.TrafficTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: "just-another-UID",
+				},
+			},
+		},
+	}
+	capacityTarget := shipper.CapacityTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRelName,
+			Namespace: testNamespaceName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID: "just-another-UID",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		Name          string
+		Backup        []shipperBackupApplication
+		ExpectedError error
+	}{
+		{
+			"Regular working restore",
+			[]shipperBackupApplication{
+				{
+					Application: application,
+					BackupReleases: []shipperBackupRelease{
+						{
+							Release:            release,
+							InstallationTarget: installationTarget,
+							TrafficTarget:      trafficTarget,
+							CapacityTarget:     capacityTarget,
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"Missing object fail restore",
+			[]shipperBackupApplication{
+				{
+					Application: application,
+					BackupReleases: []shipperBackupRelease{
+						{
+							Release:            release,
+							InstallationTarget: installationTarget,
+							CapacityTarget:     capacityTarget,
+						},
+					},
+				},
+			},
+			fmt.Errorf(
+				"failed to update traffic target owner reference: expected exactly one owner for object \"%s\" but got %d",
+				"",
+				0,
+			),
+		},
+		{
+			"Multiple owner ref release fail restore",
+			[]shipperBackupApplication{
+				{
+					Application: application,
+					BackupReleases: []shipperBackupRelease{
+						{
+							Release: shipper.Release{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      testRelName,
+									Namespace: testNamespaceName,
+									UID:       relUid,
+									OwnerReferences: []metav1.OwnerReference{
+										{
+											UID: "just-a-UID",
+										},
+										{
+											UID: "another-UID",
+										},
+									},
+								},
+							},
+							InstallationTarget: installationTarget,
+							TrafficTarget:      trafficTarget,
+							CapacityTarget:     capacityTarget,
+						},
+					},
+				},
+			},
+			fmt.Errorf(
+				"failed to update release owner reference: expected exactly one owner for object \"%s/%s\" but got %d",
+				testNamespaceName,
+				testRelName,
+				2,
+			),
+		},
+		{
+			"Multiple owner ref capacity target fail restore",
+			[]shipperBackupApplication{
+				{
+					Application: application,
+					BackupReleases: []shipperBackupRelease{
+						{
+							Release:            release,
+							InstallationTarget: installationTarget,
+							TrafficTarget:      trafficTarget,
+							CapacityTarget: shipper.CapacityTarget{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      testRelName,
+									Namespace: testNamespaceName,
+									OwnerReferences: []metav1.OwnerReference{
+										{
+											UID: "just-another-UID",
+										},
+										{
+											UID: "just-another-one-UID",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			fmt.Errorf(
+				"failed to update capacity target owner reference: expected exactly one owner for object \"%s/%s\" but got %d",
+				testNamespaceName,
+				testRelName,
+				2,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			f := newFixture(t, test.Backup, test.ExpectedError)
+			f.runRestore()
+		})
+	}
+}
+
+type fixture struct {
+	t             *testing.T
+	objects       []runtime.Object
+	backupObjects []shipperBackupApplication
+	shipperClient *shipperfake.Clientset
+	kubeClient    *kubefake.Clientset
+
+	actions       []kubetesting.Action
+	expectedError error
+}
+
+func newFixture(t *testing.T, backupObjects []shipperBackupApplication, err error) *fixture {
+	f := fixture{
+		t:             t,
+		backupObjects: backupObjects,
+		actions:       make([]kubetesting.Action, 0),
+		expectedError: err,
+	}
+	f.shipperClient = shipperfake.NewSimpleClientset()
+	f.kubeClient = kubefake.NewSimpleClientset()
+	f.addBackupObjectsAndActions(backupObjects)
+	return &f
+}
+
+func (f *fixture) runRestore() {
+	err := restore(f.backupObjects, f.kubeClient, f.shipperClient, restoreBackupCmd)
+	if !reflect.DeepEqual(err, f.expectedError) {
+		f.t.Fatalf("expected error \n%v\ngot error \n%v", f.expectedError, err)
+	}
+	actual := shippertesting.FilterActions(f.shipperClient.Actions())
+	shippertesting.CheckActions(f.actions, actual, f.t)
+
+}
+
+func (f *fixture) addCreateApplicationAction(app *shipper.Application) {
+	gvr := shipper.SchemeGroupVersion.WithResource("applications")
+	action := kubetesting.NewCreateAction(gvr, app.GetNamespace(), app)
+
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) addCreateReleaseAction(rel *shipper.Release) {
+	gvr := shipper.SchemeGroupVersion.WithResource("releases")
+	action := kubetesting.NewCreateAction(gvr, rel.GetNamespace(), rel)
+
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) addCreateITAction(it *shipper.InstallationTarget) {
+	gvr := shipper.SchemeGroupVersion.WithResource("installationtargets")
+	action := kubetesting.NewCreateAction(gvr, it.GetNamespace(), it)
+
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) addCreateTTAction(tt *shipper.TrafficTarget) {
+	gvr := shipper.SchemeGroupVersion.WithResource("traffictargets")
+	action := kubetesting.NewCreateAction(gvr, tt.GetNamespace(), tt)
+
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) addCreateCTAction(ct *shipper.CapacityTarget) {
+	gvr := shipper.SchemeGroupVersion.WithResource("capacitytargets")
+	action := kubetesting.NewCreateAction(gvr, ct.GetNamespace(), ct)
+
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) addBackupObjectsAndActions(bkups []shipperBackupApplication) {
+	for _, bkup := range bkups {
+		f.objects = append(f.objects, &bkup.Application)
+		f.addCreateApplicationAction(&bkup.Application)
+		for _, backupRelease := range bkup.BackupReleases {
+			expectedRel := backupRelease.Release.DeepCopy()
+			if len(expectedRel.OwnerReferences) != 1 {
+				return
+			}
+			expectedRel.OwnerReferences[0].UID = appUid
+			f.objects = append(f.objects, expectedRel)
+			f.addCreateReleaseAction(expectedRel)
+
+			expectedIT := backupRelease.InstallationTarget.DeepCopy()
+			if len(expectedIT.OwnerReferences) != 1 {
+				return
+			}
+			expectedIT.OwnerReferences[0].UID = relUid
+			f.objects = append(f.objects, expectedIT)
+			f.addCreateITAction(expectedIT)
+
+			expectedTT := backupRelease.TrafficTarget.DeepCopy()
+			if len(expectedTT.OwnerReferences) != 1 {
+				return
+			}
+			expectedTT.OwnerReferences[0].UID = relUid
+			f.objects = append(f.objects, expectedTT)
+			f.addCreateTTAction(expectedTT)
+
+			expectedCT := backupRelease.CapacityTarget.DeepCopy()
+			if len(expectedCT.OwnerReferences) != 1 {
+				return
+			}
+			expectedCT.OwnerReferences[0].UID = relUid
+			f.objects = append(f.objects, expectedCT)
+			f.addCreateCTAction(expectedCT)
+
+		}
+	}
+}
+
+func TestScaleDownShipper(t *testing.T) {
+	var zero int32 = 0
+	var one int32 = 1
+
+	tests := []struct {
+		Name              string
+		ShipperDeployment *appsv1.Deployment
+		ExpectedError     error
+	}{
+		{
+			"Shipper has 0 replicas",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shipper",
+					Namespace: "shipper-system",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &zero,
+				},
+			},
+			nil,
+		},
+		{
+			"Shipper has 1 replicas",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shipper",
+					Namespace: "shipper-system",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &one,
+				},
+			},
+			fmt.Errorf(
+				"shipper deployment has %d replicas. "+
+					"Scale it down first with `kubectl -n shipper-system patch deploy shipper --type=merge -p '{\"spec\":{\"replicas\":0}}'`",
+				one,
+			),
+		},
+		{
+			"Shipper is nil",
+			nil,
+			nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			fakeKube, err := initialiseFakeEnv(test.ShipperDeployment)
+			if err != nil {
+				t.Fatalf("unexpected error \n%v", err)
+			}
+			err = scaleDownShipper(restoreBackupCmd, fakeKube)
+			if !reflect.DeepEqual(err, test.ExpectedError) {
+				t.Fatalf("expected error \n%v\ngot error \n%v", test.ExpectedError, err)
+			}
+		})
+	}
+}
+
+func initialiseFakeEnv(shipperDeployment *appsv1.Deployment) (*kubefake.Clientset, error) {
+	fakeKube := kubefake.NewSimpleClientset()
+	if shipperDeployment == nil {
+		return fakeKube, nil
+	}
+	if _, err := fakeKube.AppsV1().Deployments("shipper-system").Create(shipperDeployment); err != nil {
+		return nil, err
+	}
+	return fakeKube, nil
+}
+
+func TestMakeSureNotShipperObjects(t *testing.T) {
+	tests := []struct {
+		Name           string
+		ShipperObjects []shipper.Application
+		ExpectedError  error
+	}{
+		{
+			Name:           "No shipper objects",
+			ShipperObjects: []shipper.Application{},
+			ExpectedError:  nil,
+		},
+		{
+			Name:           "Cluster's Not Empty",
+			ShipperObjects: []shipper.Application{
+				shipper.Application{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testAppName,
+						Namespace: testNamespaceName,
+						UID:       appUid,
+					},
+				},
+			},
+			ExpectedError:  fmt.Errorf(
+				"found Shipper objects:\n - %s\ndelete them first with `kubectl delete app,rel,it,tt,ct --all-namespaces --all`",
+				"Applications: 1",
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			shipperFakeClient, err := initialiseFakeEnvWithShipperApps(test.ShipperObjects)
+			if err != nil {
+				t.Fatalf("unexpected error \n%v", err)
+			}
+			err = makeSureNotShipperObjects(restoreBackupCmd, shipperFakeClient)
+			if !reflect.DeepEqual(err, test.ExpectedError) {
+				t.Fatalf("expected error \n%v\ngot error \n%v", test.ExpectedError, err)
+			}
+		})
+	}
+}
+
+func initialiseFakeEnvWithShipperApps(shipperApps []shipper.Application) (*shipperfake.Clientset, error) {
+	shipperFakeClient := shipperfake.NewSimpleClientset()
+	for _, app := range shipperApps {
+		if _, err := shipperFakeClient.ShipperV1alpha1().Applications(app.GetNamespace()).Create(&app); err != nil {
+			return nil, err
+		}
+	}
+	return shipperFakeClient, nil
+}

--- a/cmd/shipperctl/main.go
+++ b/cmd/shipperctl/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/bookingcom/shipper/cmd/shipperctl/cmd"
+	"github.com/bookingcom/shipper/cmd/shipperctl/cmd/backup"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(cmd.ClustersCmd)
 	rootCmd.AddCommand(cmd.ListCmd)
 	rootCmd.AddCommand(cmd.CleanCmd)
+	rootCmd.AddCommand(backup.BackupCmd)
 }
 
 func main() {

--- a/cmd/shipperctl/release/release.go
+++ b/cmd/shipperctl/release/release.go
@@ -103,26 +103,26 @@ func TargetObjectsForRelease(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	expectedNumbetOfTargetObjects := 1
-	if len(itList.Items) != expectedNumbetOfTargetObjects {
+	expectedNumberOfTargetObjects := 1
+	if len(itList.Items) != expectedNumberOfTargetObjects {
 		return nil, nil, nil, shippererrors.NewUnexpectedObjectCountFromSelectorError(
-			selector, shipper.SchemeGroupVersion.WithKind("InstallationTarget"), expectedNumbetOfTargetObjects, len(itList.Items))
+			selector, shipper.SchemeGroupVersion.WithKind("InstallationTarget"), expectedNumberOfTargetObjects, len(itList.Items))
 	}
 	ttList, err := shipperClient.ShipperV1alpha1().TrafficTargets(relNamespace).List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(ttList.Items) != expectedNumbetOfTargetObjects {
+	if len(ttList.Items) != expectedNumberOfTargetObjects {
 		return nil, nil, nil, shippererrors.NewUnexpectedObjectCountFromSelectorError(
-			selector, shipper.SchemeGroupVersion.WithKind("TrafficTarget"), expectedNumbetOfTargetObjects, len(itList.Items))
+			selector, shipper.SchemeGroupVersion.WithKind("TrafficTarget"), expectedNumberOfTargetObjects, len(itList.Items))
 	}
 	ctList, err := shipperClient.ShipperV1alpha1().CapacityTargets(relNamespace).List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(ctList.Items) != expectedNumbetOfTargetObjects {
+	if len(ctList.Items) != expectedNumberOfTargetObjects {
 		return nil, nil, nil, shippererrors.NewUnexpectedObjectCountFromSelectorError(
-			selector, shipper.SchemeGroupVersion.WithKind("CapacityTarget"), expectedNumbetOfTargetObjects, len(itList.Items))
+			selector, shipper.SchemeGroupVersion.WithKind("CapacityTarget"), expectedNumberOfTargetObjects, len(itList.Items))
 	}
 
 	return &itList.Items[0], &ttList.Items[0], &ctList.Items[0], err


### PR DESCRIPTION
Prepare - saves applications and releases objects to file in a tree (map) form: for each application we store the releases belonging to it.

Restore - restores from a backup file. First restore the application, populate the new UID of the application in its releases owner reference and then apply releases.

output example:
```
$ shipperctl backup -h
Backup and restore Shipper applications and releases

Usage:
  shipperctl backup [command]

Available Commands:
  prepare     Get yaml of application and release objects prepared for backup
  restore     Restore backup that was prepared using `shipperctl prepare` command

Flags:
  -f, --file string                         The path to a backup file (default "backup.yaml")
      --format string                       Output format. One of: json|yaml (default "yaml")
  -h, --help                                help for backup
      --kubeconfig string                   The path to the Kubernetes configuration file (default "~/.kube/config")
      --management-cluster-context string   The name of the context to use to communicate with the management cluster. defaults to the current one
  -v, --verbose                             Prints the list of backup items

Use "shipperctl backup [command] --help" for more information about a command.

$ shipperctl backup restore -v
Making sure shipper is down... done
Making sure there are no Shipper objects lying around... done
Would you like to see an overview of your backup? [y/n]: y
NAMESPACE  NAME                      OWNING APPLICATION
default    super-server-dc5bfc5a-0   super-server
default2   super-server2-dc5bfc5a-0  super-server2
default3   super-server3-dc5bfc5a-0  super-server3
Would you like to review backup? [y/n]: y
- application:
  ...
  releases:
  -  ...
...
Would you like to restore backup? [y/n]: y
...

$ shipperctl backup prepare -v
NAMESPACE  NAME                      OWNING APPLICATION
default    super-server-dc5bfc5a-0   super-server
default2   super-server2-dc5bfc5a-0  super-server2
default3   super-server3-dc5bfc5a-0  super-server3
Backup objects stored in "backup.yaml"

$ shipperctl backup prepare
Backup objects stored in "backup.yaml"

$ shipperctl backup prepare -f "a_new_bkup_file.json" --format json
Backup objects stored in "a_new_bkup_file.json"

## If shipper deoployment is not scaled down:
$ shipperctl backup restore
Making sure shipper is down... Error! shipper deployment has 1 replicas. Scale it down first with `kubectl -n shipper-system patch deploy shipper --type=merge -p '{"spec":{"replicas":0}}'`

## If there are shipper objects in the cluster:
$ shipperctl backup restore
Making sure shipper is down... done
Making sure there are no Shipper objects lying around... Error! found Shipper objects:
 - Applications: 3
 - Releases: 3
 - InstallationTargets: 3
 - TrafficTargets: 3
 - CapacityTargets: 3
delete them first with `kubectl delete app,rel,it,tt,ct --all-namespaces --all`

```