### PR TITLE
Rearrange strategy executor

### DIFF
--- a/pkg/controller/release/release_controller.go
+++ b/pkg/controller/release/release_controller.go
@@ -500,7 +500,7 @@ func (c *Controller) recordEvents(rel *shipper.Release, achievedStep int32, prev
 	}
 }
 
-func strategyAndStepToExecute(rel *shipper.Release, relinfoSucc *releaseInfo, ) (*shipper.RolloutStrategy, int32, error) {
+func strategyAndStepToExecute(rel *shipper.Release, relinfoSucc *releaseInfo) (*shipper.RolloutStrategy, int32, error) {
 	var succ *shipper.Release
 	if relinfoSucc != nil {
 		succ = relinfoSucc.release


### PR DESCRIPTION
Split `executeReleaseStrategy` to sections.
`executeReleaseStrategy` method is doing:
1. build relInfo for the current release, previous and successor (relInfo is a struct of the release and its' target objects)
2. choosing strategy and step according the the 3 releases
3. executing strategy
4. updating logs, conditions, events