### PR TITLE
Updating ImagePullPolicy to IfNotPresent

### DIFF
--- a/kubernetes/shipper-state-metrics.deployment.yaml
+++ b/kubernetes/shipper-state-metrics.deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: shipper-state-metrics
         image: <IMAGE>
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - "-v"
           - "2"

--- a/kubernetes/shipper.deployment.yaml
+++ b/kubernetes/shipper.deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: shipper
         image: <IMAGE>
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - "-webhook-cert"
           - "/etc/webhook/certs/tls.crt"


### PR DESCRIPTION
This means that if the artifactory service hosting Shippers images is down at the same moment of an update to the manifest (not to the image), Shipper's pod will not be stuck in ImagePullBackOff