### PR TITLE
Measure time from Application creation/modification to Chart Installation

### DIFF
--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -536,7 +536,7 @@ func startMetricsController(cfg *cfg) (bool, error) {
 
 	cfg.wg.Add(1)
 	go func() {
-		c.Run(cfg.workers, cfg.stopCh)
+		c.Run(cfg.stopCh)
 		cfg.wg.Done()
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/rodaine/table v1.0.1
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/pkg/controller/metrics/metrics_bundle.go
+++ b/pkg/controller/metrics/metrics_bundle.go
@@ -1,0 +1,19 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MetricsBundle encapsulates all the metrics that the Metrics Controller reports on.
+type MetricsBundle struct {
+	TimeToInstallation prometheus.Histogram
+}
+
+func NewMetricsBundle() *MetricsBundle {
+	timeToInstallation := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "Time to installation",
+		Help: "The time it takes for a Release to be installed on all of the clusters it's scheduled on",
+	})
+
+	return &MetricsBundle{
+		TimeToInstallation: timeToInstallation,
+	}
+}

--- a/pkg/controller/metrics/metrics_bundle.go
+++ b/pkg/controller/metrics/metrics_bundle.go
@@ -9,8 +9,10 @@ type MetricsBundle struct {
 
 func NewMetricsBundle() *MetricsBundle {
 	timeToInstallation := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "Time to installation",
-		Help: "The time it takes for a Release to be installed on all of the clusters it's scheduled on",
+		Namespace: "shipper",
+		Subsystem: "metrics_controller",
+		Name:      "time_to_installation",
+		Help:      "The time it takes for a Release to be installed on all of the clusters it's scheduled on",
 	})
 
 	return &MetricsBundle{

--- a/pkg/controller/metrics/metrics_controller.go
+++ b/pkg/controller/metrics/metrics_controller.go
@@ -1,0 +1,206 @@
+package metrics
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	objectutil "github.com/bookingcom/shipper/pkg/util/object"
+
+	corev1 "k8s.io/api/core/v1"
+
+	releaseconditions "github.com/bookingcom/shipper/pkg/util/release"
+
+	listers "github.com/bookingcom/shipper/pkg/client/listers/shipper/v1alpha1"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	clientset "github.com/bookingcom/shipper/pkg/client/clientset/versioned"
+
+	informers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+)
+
+const (
+	AgentName = "metrics-controller"
+)
+
+// Controller is the controller implementation for gathering metrics
+// in real-time by subscribing to events
+type Controller struct {
+	appLister  listers.ApplicationLister
+	appsSynced cache.InformerSynced
+
+	releaseLister  listers.ReleaseLister
+	releasesSynced cache.InformerSynced
+
+	recorder record.EventRecorder
+
+	shipperClientset clientset.Interface
+
+	appLastModifiedTimes     map[string]time.Time
+	appLastModifiedTimesLock sync.Mutex
+
+	metricsBundle *MetricsBundle
+}
+
+func NewController(
+	shipperClientset clientset.Interface,
+	shipperInformerFactory informers.SharedInformerFactory,
+	recorder record.EventRecorder,
+	metricsBundle *MetricsBundle,
+) *Controller {
+	appInformer := shipperInformerFactory.Shipper().V1alpha1().Applications()
+	relInformer := shipperInformerFactory.Shipper().V1alpha1().Releases()
+
+	c := &Controller{
+		shipperClientset: shipperClientset,
+
+		appLister:  appInformer.Lister(),
+		appsSynced: appInformer.Informer().HasSynced,
+
+		releaseLister:  relInformer.Lister(),
+		releasesSynced: relInformer.Informer().HasSynced,
+
+		recorder:      recorder,
+		metricsBundle: metricsBundle,
+	}
+
+	appInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.handleAppCreates,
+		UpdateFunc: c.handleAppUpdates,
+		// TODO(parhamdoustdar): handle deletes to measure how long it takes us to do garbage collection
+	})
+
+	relInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: c.handleReleaseUpdates,
+		// TODO(parhamdoustdar): handle deletions as well, since we use them to do garbage collection
+	})
+
+	return c
+}
+
+// Run will set up the event handlers for types we are interested in, as well
+// as syncing informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
+	defer runtime.HandleCrash()
+
+	klog.V(2).Info("Starting Metrics controller")
+	defer klog.V(2).Info("Shutting down Metrics controller")
+
+	if !cache.WaitForCacheSync(stopCh, c.appsSynced, c.releasesSynced) {
+		runtime.HandleError(fmt.Errorf("failed to wait for caches to sync"))
+		return
+	}
+
+	klog.V(4).Info("Started Metrics controller")
+
+	<-stopCh
+}
+
+func (c *Controller) handleAppCreates(obj interface{}) {
+	app, ok := obj.(*shipper.Application)
+	if !ok {
+		return
+	}
+
+	c.appLastModifiedTimesLock.Lock()
+	defer c.appLastModifiedTimesLock.Unlock()
+
+	// We don't need the extra marshalling support that
+	// metav1.Time provides, because we're not going to pass this
+	// value around with HTTP
+	c.appLastModifiedTimes[app.Name] = app.GetCreationTimestamp().Time
+
+	return
+}
+
+func (c *Controller) handleAppUpdates(old, new interface{}) {
+	oldApp, ok := old.(*shipper.Application)
+	if !ok {
+		return
+	}
+
+	newApp, ok := new.(*shipper.Application)
+	if !ok {
+		return
+	}
+
+	// If the specs are the same, this is not a user modification
+	// and should be ignored
+	if !reflect.DeepEqual(oldApp.Spec, newApp.Spec) {
+		return
+	}
+
+	c.appLastModifiedTimesLock.Lock()
+	defer c.appLastModifiedTimesLock.Unlock()
+
+	// Kubernetes doesn't give us the last modified time, so we'll
+	// just have to use the time from our side
+	// TODO: if there is a better way to do this, please go ahead!
+	c.appLastModifiedTimes[newApp.Name] = time.Now()
+
+	return
+}
+
+func (c *Controller) handleReleaseUpdates(old, new interface{}) {
+	oldRelease, ok := old.(*shipper.Release)
+	if !ok {
+		return
+	}
+
+	newRelease, ok := new.(*shipper.Release)
+	if !ok {
+		return
+	}
+
+	// If the chart wasn't installed and now it is, calculate how
+	// long it took. The chart is always installed on step 0, so
+	// return if we've passed that step
+	if newRelease.Spec.TargetStep > 0 {
+		return
+	}
+
+	oldInstallationCondition := releaseconditions.GetReleaseStrategyConditionByType(oldRelease.Status.Strategy, shipper.StrategyConditionContenderAchievedInstallation)
+	newInstallationCondition := releaseconditions.GetReleaseStrategyConditionByType(newRelease.Status.Strategy, shipper.StrategyConditionContenderAchievedInstallation)
+	if newInstallationCondition != nil {
+		return
+	}
+
+	if oldInstallationCondition != nil && oldInstallationCondition.Status == corev1.ConditionTrue {
+		// This release has already achieved installation, so ignore
+		return
+	}
+
+	if newInstallationCondition.Status == corev1.ConditionFalse {
+		return
+	}
+
+	// Yay! Contender has achieved installation!
+	releaseName, err := cache.MetaNamespaceKeyFunc(newRelease)
+	if err != nil {
+		klog.Errorf("Failed to get release key: %q", err)
+	}
+
+	appName, err := objectutil.GetApplicationLabel(newRelease)
+	if err != nil {
+		klog.Errorf("Could not find application name for Release %q", releaseName)
+	}
+
+	lastModifiedTime, ok := c.appLastModifiedTimes[appName]
+	if !ok {
+		// This probably means the 8informer didn't
+		// run our application create/update callback,
+		// so silently ignore the error
+		return
+	}
+
+	installationDuration := newInstallationCondition.LastTransitionTime.Sub(lastModifiedTime)
+	c.metricsBundle.TimeToInstallation.Observe(installationDuration.Seconds())
+}

--- a/pkg/controller/metrics/metrics_controller_test.go
+++ b/pkg/controller/metrics/metrics_controller_test.go
@@ -1,0 +1,196 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	shippertesting "github.com/bookingcom/shipper/pkg/testing"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMetricsControllerCreateAndUpdatesCache(t *testing.T) {
+	f := shippertesting.NewControllerTestFixture()
+	c := runController(f)
+
+	// adds the app to the cache
+	creationTime := parseTime("Jan 22 2021 08:38:22")
+	creationTimeWrapped := metav1.NewTime(creationTime)
+	app := &shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: creationTimeWrapped,
+			Name:              "unit-test-app",
+		},
+	}
+
+	c.handleAppCreates(app)
+	entry, ok := c.appLastModifiedTimes[app.Name]
+	if !ok {
+		t.Fatalf("expected %q to be in cache, got %v", app.Name, c.appLastModifiedTimes)
+	}
+	if !entry.time.Equal(creationTime) {
+		t.Fatalf("expected time to be the same as creation time\nentry.time = %s\ncreationTime = %s\n", entry.time, creationTime)
+	}
+
+	// if the spec doesn't change than ignore the update
+	appWithLabels := &shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: app.ObjectMeta.CreationTimestamp,
+			Name:              "unit-test-app",
+			Labels: map[string]string{
+				"random": "label",
+			},
+		},
+	}
+	c.handleAppUpdates(app, appWithLabels)
+	entry, ok = c.appLastModifiedTimes[app.Name]
+	if !ok {
+		t.Fatalf("expected %q to be in cache, got %v", app.Name, c.appLastModifiedTimes)
+	}
+	if !entry.time.Equal(creationTime) {
+		t.Fatalf("expected time to be the same as creation time\nentry.time = %s\ncreationTime = %s\n", entry.time, creationTime)
+	}
+
+	// if the spec does change update the cache entry
+	var one int32 = 1
+	appWithSpec := &shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: app.ObjectMeta.CreationTimestamp,
+			Name:              "unit-test-app",
+		},
+		Spec: shipper.ApplicationSpec{
+			RevisionHistoryLimit: &one,
+		},
+	}
+	c.handleAppUpdates(app, appWithSpec)
+	entry, ok = c.appLastModifiedTimes[app.Name]
+	if !ok {
+		t.Fatalf("expected %q to be in cache, got %v", app.Name, c.appLastModifiedTimes)
+	}
+	if entry.time.Equal(creationTime) {
+		t.Fatalf("expected time to be the differt from the creation time\nentry.time = %s\ncreationTime = %s\n", entry.time, creationTime)
+	}
+}
+
+func TestMetricsControllerCalculateTimeToInstall(t *testing.T) {
+	app := &shipper.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.NewTime(parseTime("Jan 22 2021 08:38:22")),
+			Name:              "unit-test-app",
+			Namespace:         "unit-test-ns",
+		},
+	}
+	oldRelease := &shipper.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-test",
+			Namespace: "unit-test-ns",
+			Labels: map[string]string{
+				shipper.AppLabel: "unit-test-app",
+			},
+			Annotations: map[string]string{
+				shipper.ReleaseGenerationAnnotation: "1",
+			},
+		},
+		Status: shipper.ReleaseStatus{
+			Strategy: &shipper.ReleaseStrategyStatus{
+				Conditions: []shipper.ReleaseStrategyCondition{
+					{
+						Type:   shipper.StrategyConditionContenderAchievedInstallation,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		},
+	}
+	newRelease := &shipper.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-test",
+			Namespace: "unit-test-ns",
+			Labels: map[string]string{
+				shipper.AppLabel: "unit-test-app",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "unit-test-app",
+				},
+			},
+		},
+		Spec: shipper.ReleaseSpec{
+			TargetStep: 0,
+		},
+		Status: shipper.ReleaseStatus{
+			Strategy: &shipper.ReleaseStrategyStatus{
+				Conditions: []shipper.ReleaseStrategyCondition{
+					{
+						Type:               shipper.StrategyConditionContenderAchievedInstallation,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(parseTime("Jan 22 2021 09:38:22")),
+					},
+				},
+			},
+		},
+	}
+
+	f := shippertesting.NewControllerTestFixture(app, oldRelease)
+	c := runController(f)
+
+	// adds the app to the cache
+	c.handleAppCreates(app)
+
+	// calculate time to installation
+	c.handleReleaseUpdates(oldRelease, newRelease)
+
+	// get the metrics
+	fakeHistogram := c.metricsBundle.TimeToInstallation.(*fakeHistogram)
+	if len(fakeHistogram.data) != 1 {
+		t.Fatalf("expected exactly one metric, got %v", fakeHistogram.data)
+	}
+	if fakeHistogram.data[0] != 3600.0 {
+		t.Fatalf("expected installation time to be 3600s but got %f", fakeHistogram.data[0])
+	}
+}
+
+func runController(f *shippertesting.ControllerTestFixture) *Controller {
+	c := NewController(
+		f.ShipperClient,
+		f.ShipperInformerFactory,
+		fakeMetricsBundle(),
+	)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	f.Run(stopCh)
+
+	return c
+}
+
+func parseTime(str string) time.Time {
+	layout := "Jan 02 2006 15:04:05"
+	t, _ := time.Parse(layout, str)
+	return t
+}
+
+func fakeMetricsBundle() *MetricsBundle {
+	return &MetricsBundle{
+		TimeToInstallation: &fakeHistogram{
+			data: make([]float64, 0),
+		},
+	}
+}
+
+type fakeHistogram struct {
+	data []float64
+}
+
+func (f *fakeHistogram) Observe(m float64) {
+	f.data = append(f.data, m)
+}
+
+func (f *fakeHistogram) Describe(chan<- *prometheus.Desc) {}
+func (f *fakeHistogram) Collect(chan<- prometheus.Metric) {}
+func (f *fakeHistogram) Desc() *prometheus.Desc           { return nil }
+func (f *fakeHistogram) Write(*dto.Metric) error          { return nil }

--- a/pkg/testing/controller_test_fixture.go
+++ b/pkg/testing/controller_test_fixture.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -23,10 +24,10 @@ type ControllerTestFixture struct {
 	Recorder *record.FakeRecorder
 }
 
-func NewControllerTestFixture() *ControllerTestFixture {
+func NewControllerTestFixture(objects ...runtime.Object) *ControllerTestFixture {
 	const recorderBufSize = 42
 
-	shipperClient := shipperfake.NewSimpleClientset()
+	shipperClient := shipperfake.NewSimpleClientset(objects...)
 	shipperInformerFactory := shipperinformers.NewSharedInformerFactory(
 		shipperClient, NoResyncPeriod)
 

--- a/pkg/util/release/conditions.go
+++ b/pkg/util/release/conditions.go
@@ -123,3 +123,13 @@ func filterOutCondition(conditions []shipper.ReleaseCondition, condType shipper.
 	}
 	return newConditions
 }
+
+func GetReleaseStrategyConditionByType(strategyStatus *shipper.ReleaseStrategyStatus, strategyType shipper.StrategyConditionType) *shipper.ReleaseStrategyCondition {
+	for _, condition := range strategyStatus.Conditions {
+		if condition.Type == strategyType {
+			return &condition
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is the first iteration of gathering information from the moment
an application is modified to the moment that the chart is
installed. We're measuring the time it takes Shipper to render the
chart, install it, and report that it has been installed
