### PR TITLE
Makefile: Image name with tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,8 @@ build/%.tar.gz: build/%
 # if you have "shipper" in $*, IMAGE_NAME_WITH_TAG will read from
 # $(SHIPPER_IMAGE).
 IMAGE_NAME_WITH_TAG = $($(subst -,_,$(shell echo $* | tr '[:lower:]' '[:upper:]'))_IMAGE)
+SHIPPER_IMAGE_NAME_WITH_TAG = $($(subst -,_,$(shell echo "shipper" | tr '[:lower:]' '[:upper:]'))_IMAGE)
+SHIPPER_STATE_METRICS_IMAGE_NAME_WITH_TAG = $($(subst -,_,$(shell echo "shipper-state-metrics" | tr '[:lower:]' '[:upper:]'))_IMAGE)
 
 # The shipper and shipper-state-metrics targets here are phony and
 # supposed to be used directly, as a shorthand. They call their close cousins

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -8,7 +8,7 @@ kubectl config use-context kind-mgmt
 SETUP_MGMT_FLAGS="--webhook-ignore" make setup
 
 # Run the e2e tests, save exit code for later
-OVERLAY_PATH=kubernetes/overlays/test make -j e2e \
+IMAGE_TAG=latest OVERLAY_PATH=kubernetes/overlays/test make -j e2e \
 	TEST_HELM_REPO_URL=${TEST_HELM_REPO_URL:=https://raw.githubusercontent.com/bookingcom/shipper/${GITHUB_SHA}/test/e2e/testdata} \
 	DOCKER_REGISTRY=${DOCKER_REGISTRY:=localhost:5000} \
 	E2E_FLAGS="--test.v --buildAppClientFromKubeConfig"


### PR DESCRIPTION
redefine IMAGE_NAME_WITH_TAG to shipper and shipper-state-metrics for makefile to know which image with tag to use