### PR TITLE
Tests

### DIFF
--- a/pkg/util/rolloutblock/blocks.go
+++ b/pkg/util/rolloutblock/blocks.go
@@ -40,8 +40,6 @@ func BlocksRollout(rolloutBlockLister shipperlisters.RolloutBlockLister, obj met
 		return true, events, err
 	}
 
-	obj.SetAnnotations(annotations)
-
 	effectiveBlocks := existingBlocks.Diff(overrides)
 
 	if len(effectiveBlocks) == 0 {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,7 +30,7 @@ var (
 	inspectFailed                = flag.Bool("inspectfailed", false, "Set this flag to skip deleting the namespaces for failed tests. Useful for debugging.")
 	kubeconfig                   = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	appClusterName               = flag.String("appcluster", "minikube", "The application cluster that E2E tests will check to determine success/failure")
-	timeoutFlag                  = flag.String("progresstimeout", "30s", "timeout when waiting for things to change")
+	timeoutFlag                  = flag.String("progresstimeout", "90s", "timeout when waiting for things to change")
 	buildAppClientFromKubeConfig = flag.Bool("buildAppClientFromKubeConfig", false, "Set this flag to get application client from kubeconfig.")
 )
 


### PR DESCRIPTION
Increase timeout of e2e tests and remove unnecessary set annotations that can create race condition.

We have seen flappy e2e tests on CI pipeline runners for a while. They fail with
```
timed out waiting for release to be waiting for none: waited 30s. final state: {installation: False, capacity: False, traffic: True, command: False}
```
which means they need more time to converge.