### PR TITLE
Raise timeout to fetch charts index

### DIFF
--- a/pkg/chart/repo/repo.go
+++ b/pkg/chart/repo/repo.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	RepoIndexRefreshPeriod = 10 * time.Second
-	RepoFetchIndexTimeout  = 2 * time.Second
+	RepoFetchIndexTimeout  = 4 * time.Second
 )
 
 var ErrFetchNoResponseYet = errors.New("no response from chart repo yet")


### PR DESCRIPTION
`shipperctl chart render` timesout when fetching charts index from some repositories. Raising the timeout to 4 seconds seems to help.