### PR TITLE
Webhook validates deletion

### DIFF
--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -428,6 +428,7 @@ func (c *Cluster) CreateOrUpdateValidatingWebhookConfiguration(caBundle []byte, 
 						Operations: []admissionregistrationv1beta1.OperationType{
 							admissionregistrationv1beta1.Create,
 							admissionregistrationv1beta1.Update,
+							admissionregistrationv1beta1.Delete,
 						},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{shipper.SchemeGroupVersion.Group},

--- a/cmd/shipperctl/configurator/cluster_test.go
+++ b/cmd/shipperctl/configurator/cluster_test.go
@@ -28,6 +28,7 @@ func TestCreateValidatingWebhookConfiguration(t *testing.T) {
 	operations := []admissionregistrationv1beta1.OperationType{
 		admissionregistrationv1beta1.Create,
 		admissionregistrationv1beta1.Update,
+		admissionregistrationv1beta1.Delete,
 	}
 	expectedConfiguration := f.newValidatingWebhookConfiguration(caBundle, shipperSystemNamespace, operations)
 	gvr := admissionregistrationv1beta1.SchemeGroupVersion.WithResource("validatingwebhookconfigurations")
@@ -65,6 +66,7 @@ func TestUpdateValidatingWebhookConfiguration(t *testing.T) {
 	operations = []admissionregistrationv1beta1.OperationType{
 		admissionregistrationv1beta1.Create,
 		admissionregistrationv1beta1.Update,
+		admissionregistrationv1beta1.Delete,
 	}
 	expectedConfiguration := f.newValidatingWebhookConfiguration(caBundle, shipperSystemNamespace, operations)
 	getAction := kubetesting.NewGetAction(gvr, "", expectedConfiguration.Name)

--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -249,9 +249,10 @@ func newRolloutBlock(name string, namespace string) *shipper.RolloutBlock {
 func buildApplication(namespace string, appName string) *shipper.Application {
 	return &shipper.Application{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appName,
-			Namespace: namespace,
-			UID:       "foobarbaz",
+			Name:        appName,
+			Namespace:   namespace,
+			UID:         "foobarbaz",
+			Annotations: make(map[string]string),
 		},
 		Status: shipper.ApplicationStatus{
 			History: []string{},

--- a/pkg/util/rolloutblock/blocks.go
+++ b/pkg/util/rolloutblock/blocks.go
@@ -90,3 +90,11 @@ func ValidateAnnotations(existing, overrides ObjectNameList) error {
 	}
 	return nil
 }
+
+func ApplicationOverrides(applicationOverrides, releaseOverrides string) string {
+	appOverrides := NewObjectNameList(applicationOverrides)
+	relOverrides := NewObjectNameList(releaseOverrides)
+	diff := relOverrides.Diff(appOverrides)
+	appOverrides.AddMultiple(diff)
+	return appOverrides.String()
+}

--- a/pkg/util/rolloutblock/object_name_list.go
+++ b/pkg/util/rolloutblock/object_name_list.go
@@ -61,6 +61,12 @@ func (o ObjectNameList) Add(statement string) {
 	o[statement] = struct{}{}
 }
 
+func (o ObjectNameList) AddMultiple(o2 ObjectNameList) {
+	for s := range o2 {
+		o.Add(s)
+	}
+}
+
 func (o ObjectNameList) Diff(o2 ObjectNameList) ObjectNameList {
 	res := make(ObjectNameList)
 	for s := range o {


### PR DESCRIPTION
This adds Delete action to validating webhook. 
This is necessary for when there's a rollout block and a user is not aware. In this case, the user might delete the contender, but shipper will not reactivate the incumbent.

Shipper will also populate override annotations from releases to owning applications, to prevent a case where an overriding release is deleted, but the application is not overriding the block so Shipper will not reactivated incumbent release.