### PR TITLE
Installation controller fails to create when a namespace is terminating

### DIFF
--- a/CHANGELOG-0.10.md
+++ b/CHANGELOG-0.10.md
@@ -51,6 +51,8 @@
 * Fix dropping pods when moving back in the strategy([#387][])
 * Webhook validates deletion. This prevents users to delete release 
   objects when there's a rollout block thus creating an outage for their service ([#392][])
+* Fixed a bug in the installation target where a deleted namespace in application cluster 
+  related error will never be retried ([#396][]))
 
 ### Migrating to 0.10
 
@@ -86,4 +88,5 @@
 [#383]: https://github.com/bookingcom/shipper/pull/383
 [#387]: https://github.com/bookingcom/shipper/pull/387
 [#392]: https://github.com/bookingcom/shipper/pull/392
+[#396]: https://github.com/bookingcom/shipper/pull/396
 [failure policy]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -1,7 +1,7 @@
 .. _start:
 
 ####################
-Shipper in 5 minutes
+Installing Shipper
 ####################
 
 *************************
@@ -169,6 +169,23 @@ Step 6: do a rollout!
 *********************
 
 Now you should have a working Shipper installation. :ref:`Let's roll something out! <user_rolling-out>`
+
+
+*****************
+Namespace manager
+*****************
+By design, Shipper does not create namespaces in the application cluster.
+Shipper requires the existence of a namespace in the application cluster with the same name as the namespace in
+management cluster where the *Application* objects is installed.
+In case the namespace does not exist in the application cluster, and this application cluster is selected for a *Release*,
+Shipper will continue to try and install the charts, and fail.
+This loop will end only when the namespace is created in the application cluster,
+or this application cluster is not selected anymore (by deleting the *Release* or *Application* objects).
+
+To help with this, we recommend having some sort of a namespace manager tool.
+This can be a simple controller that installs a namespace in all the application clusters
+for each namespace existing in the management cluster, or a more complex tool, depending on your needs.
+
 
 .. rubric:: Footnotes
 

--- a/pkg/controller/installation/installer.go
+++ b/pkg/controller/installation/installer.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shippererrors "github.com/bookingcom/shipper/pkg/errors"
@@ -109,6 +110,13 @@ func (i *Installer) install(
 	} else if err != nil { // errors.IsNotFound(err) == true
 		createdConfigMap, err = client.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
 		if err != nil {
+			klog.Warningf(
+				"failed to create anchor ConfigMap %s/%s in cluster %s: %+v",
+				configMap.Namespace,
+				configMap.Name,
+				cluster.Name,
+				err,
+				)
 			return shippererrors.NewKubeclientCreateError(configMap, err).
 				WithCoreV1Kind("ConfigMap")
 		}


### PR DESCRIPTION
This change makes the kubeclient error with cause `Namespace Terminating`, or a forbidden (404) error with kind `namespaces` (namespace not found error) retryable