### PR TITLE
Update rolloutblockerror to be consistent with other errors

### DIFF
--- a/pkg/controller/release/release_controller_test.go
+++ b/pkg/controller/release/release_controller_test.go
@@ -22,6 +22,7 @@ import (
 	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
 	shipperfake "github.com/bookingcom/shipper/pkg/client/clientset/versioned/fake"
 	shipperinformers "github.com/bookingcom/shipper/pkg/client/informers/externalversions"
+	shippererrors "github.com/bookingcom/shipper/pkg/errors"
 	shippertesting "github.com/bookingcom/shipper/pkg/testing"
 	apputil "github.com/bookingcom/shipper/pkg/util/application"
 	"github.com/bookingcom/shipper/pkg/util/conditions"
@@ -1789,7 +1790,7 @@ func TestContenderCapacityShouldNotIncreaseWithRolloutBlock(t *testing.T) {
 	)
 
 	expectedContender := contender.release.DeepCopy()
-	rolloutBlockMessage := fmt.Sprintf("rollout block(s) with name(s) %s exist", rolloutBlockKey)
+	rolloutBlockMessage := shippererrors.NewRolloutBlockError(rolloutBlockKey).Error()
 	condBlocked := releaseutil.NewReleaseCondition(
 		shipper.ReleaseConditionTypeBlocked,
 		corev1.ConditionTrue,
@@ -1921,7 +1922,7 @@ func TestContenderTrafficShouldNotIncreaseWithRolloutBlock(t *testing.T) {
 	)
 
 	expectedContender := contender.release.DeepCopy()
-	rolloutBlockMessage := fmt.Sprintf("rollout block(s) with name(s) %s exist", rolloutBlockKey)
+	rolloutBlockMessage := shippererrors.NewRolloutBlockError(rolloutBlockKey).Error()
 	condBlocked := releaseutil.NewReleaseCondition(
 		shipper.ReleaseConditionTypeBlocked,
 		corev1.ConditionTrue,
@@ -2048,7 +2049,7 @@ func TestIncumbentTrafficShouldNotDecreaseWithRolloutBlock(t *testing.T) {
 	)
 
 	expectedContender := contender.release.DeepCopy()
-	rolloutBlockMessage := fmt.Sprintf("rollout block(s) with name(s) %s exist", rolloutBlockKey)
+	rolloutBlockMessage := shippererrors.NewRolloutBlockError(rolloutBlockKey).Error()
 	condBlocked := releaseutil.NewReleaseCondition(
 		shipper.ReleaseConditionTypeBlocked,
 		corev1.ConditionTrue,
@@ -2179,7 +2180,7 @@ func TestIncumbentCapacityShouldNotDecreaseWithRolloutBlock(t *testing.T) {
 	)
 
 	expectedContender := contender.release.DeepCopy()
-	rolloutBlockMessage := fmt.Sprintf("rollout block(s) with name(s) %s exist", rolloutBlockKey)
+	rolloutBlockMessage := shippererrors.NewRolloutBlockError(rolloutBlockKey).Error()
 	condBlocked := releaseutil.NewReleaseCondition(
 		shipper.ReleaseConditionTypeBlocked,
 		corev1.ConditionTrue,

--- a/pkg/errors/rolloutblock.go
+++ b/pkg/errors/rolloutblock.go
@@ -9,7 +9,7 @@ type InvalidRolloutBlockOverrideError struct {
 }
 
 func (e InvalidRolloutBlockOverrideError) Error() string {
-	return fmt.Sprintf("rollout block with name %s does not exist",
+	return fmt.Sprintf("rollout block with name %q does not exist",
 		e.RolloutBlockName)
 }
 
@@ -21,17 +21,19 @@ func NewInvalidRolloutBlockOverrideError(invalidRolloutBlockName string) Invalid
 	return InvalidRolloutBlockOverrideError{invalidRolloutBlockName}
 }
 
-type RolloutBlockError string
+type RolloutBlockError struct {
+	RolloutBlockName string
+}
 
 func (e RolloutBlockError) Error() string {
-	return string(e)
+	return fmt.Sprintf("rollout block(s) with name(s) %q exist",
+		e.RolloutBlockName)
 }
 
 func (e RolloutBlockError) ShouldRetry() bool {
 	return false
 }
 
-func NewRolloutBlockError(invalidRolloutBlockName string) RolloutBlockError {
-	return RolloutBlockError(fmt.Sprintf("rollout block(s) with name(s) %s exist",
-		invalidRolloutBlockName))
+func NewRolloutBlockError(rolloutBlockName string) RolloutBlockError {
+	return RolloutBlockError{rolloutBlockName}
 }


### PR DESCRIPTION
This MR updates the RolloutBlockError to be consistent with other errors and makes it more reusable.