### PR TITLE
Extend WebhookConfigurations to any apiVersion

### DIFF
--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -432,7 +432,7 @@ func (c *Cluster) CreateOrUpdateValidatingWebhookConfiguration(caBundle []byte, 
 						},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{shipper.SchemeGroupVersion.Group},
-							APIVersions: []string{shipper.SchemeGroupVersion.Version},
+							APIVersions: []string{"*"},
 							Resources:   []string{"*"},
 						},
 					},

--- a/cmd/shipperctl/configurator/cluster_test.go
+++ b/cmd/shipperctl/configurator/cluster_test.go
@@ -175,7 +175,7 @@ func (f *fixture) newValidatingWebhookConfiguration(caBundle []byte, namespace s
 						Operations: operations,
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{shipper.SchemeGroupVersion.Group},
-							APIVersions: []string{shipper.SchemeGroupVersion.Version},
+							APIVersions: []string{"*"},
 							Resources:   []string{"*"},
 						},
 					},


### PR DESCRIPTION
We'd rather fail close on validation that an object unvalidated reach the cluster.