### PR TITLE
Create explicit Shipper application cluster role

### DIFF
--- a/cmd/shipperctl/configurator/cluster.go
+++ b/cmd/shipperctl/configurator/cluster.go
@@ -70,40 +70,18 @@ func (c *Cluster) CreateServiceAccount(domain, namespace string, name string) er
 	return err
 }
 
-func (c *Cluster) CreateClusterRole(domain, name string) error {
-	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				shipper.RBACDomainLabel: domain,
-			},
-		},
-		Rules: []rbacv1.PolicyRule{
-			rbacv1.PolicyRule{
-				Verbs:     []string{rbacv1.VerbAll},
-				APIGroups: []string{shipper.SchemeGroupVersion.Group},
-				Resources: []string{rbacv1.ResourceAll},
-			},
-			rbacv1.PolicyRule{
-				Verbs:     []string{"update", "get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-			},
-			rbacv1.PolicyRule{
-				Verbs:     []string{rbacv1.VerbAll},
-				APIGroups: []string{""},
-				Resources: []string{"events"},
-			},
-			rbacv1.PolicyRule{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"namespaces"},
-			},
-		},
-	}
+func (c *Cluster) CreateApplicationClusterRole(name, domain string) error {
+	err := c.createClusterRole(getApplicationClusterRole(name, domain))
+	return err
+}
 
-	_, err := c.KubeClient.RbacV1().ClusterRoles().Create(clusterRole)
+func (c *Cluster) CreateManagementClusterRole(name, domain string) error {
+	err := c.createClusterRole(getManagementClusterRole(name, domain))
+	return err
+}
 
+func (c *Cluster) createClusterRole(role *rbacv1.ClusterRole) error {
+	_, err := c.KubeClient.RbacV1().ClusterRoles().Create(role)
 	return err
 }
 

--- a/cmd/shipperctl/configurator/roles.go
+++ b/cmd/shipperctl/configurator/roles.go
@@ -1,0 +1,88 @@
+package configurator
+
+import (
+	shipper "github.com/bookingcom/shipper/pkg/apis/shipper/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getManagementClusterRole(name, domain string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{rbacv1.VerbAll},
+				APIGroups: []string{shipper.SchemeGroupVersion.Group},
+				Resources: []string{rbacv1.ResourceAll},
+			},
+			{
+				Verbs:     []string{"update", "get", "list", "watch"},
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+			},
+			{
+				Verbs:     []string{rbacv1.VerbAll},
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+			},
+		},
+	}
+}
+
+func getApplicationClusterRole(name, domain string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"patch",
+					"delete",
+					"update",
+					"create",
+					"deletecollection",
+				},
+				APIGroups: []string{
+					"",
+					"extensions",
+					"apps",
+					"batch",
+					rbacv1.GroupName,
+				},
+				Resources: []string{
+					"pods",
+					"pods/log",
+					"services",
+					"deployments",
+					"replicasets",
+					"statefulsets",
+					"secrets",
+					"configmaps",
+					"jobs",
+					"cronjobs",
+					"persistentvolumeclaims",
+					"endpoints",
+					"rolebindings",
+					"roles",
+					"serviceaccounts",
+				},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This MR changes shipperctl so that it creates an explicit application-cluster role with fewer permissions. Previously shipperctl would give shipper cluster admin rights to the application clusters.